### PR TITLE
Implement Repository Profiling (LOC + File Type Breakdown)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ts-repo-metrics
 
-A TypeScript CLI tool that statically analyzes TypeScript and TSX repositories using [Tree-sitter](https://tree-sitter.github.io/tree-sitter/), producing a JSON report with file counts, function counts, and per-file breakdowns by function type.
+A TypeScript CLI tool that statically analyzes TypeScript and TSX repositories using [Tree-sitter](https://tree-sitter.github.io/tree-sitter/), producing a JSON report with repository profiling (LOC and file type breakdown), function counts, and per-file breakdowns by function type.
 
 ## Prerequisites
 
@@ -29,6 +29,15 @@ npm run dev -- /absolute/path/to/target/repo
 {
   "repoPath": "/path/to/repo",
   "filesAnalyzed": 5,
+  "profile": {
+    "totalFiles": 5,
+    "tsFiles": 5,
+    "tsxFiles": 0,
+    "testFiles": 0,
+    "totalLOC": 120,
+    "sourceLOC": 120,
+    "testLOC": 0
+  },
   "totals": {
     "functions": 7
   },
@@ -55,13 +64,14 @@ npm run dev -- /absolute/path/to/target/repo
 src/
 ├── cli.ts                      # CLI entrypoint
 ├── collect/
-│   └── fileDiscovery.ts        # Finds .ts/.tsx files via fast-glob
+│   ├── fileDiscovery.ts        # Finds .ts/.tsx files via fast-glob
+│   └── loc.ts                  # Repository profiling (LOC + file type breakdown)
 ├── parsing/
 │   └── tsParser.ts             # Tree-sitter wrapper (TS & TSX grammars)
 ├── extract/
 │   └── functionCount.ts        # Counts functions by AST node type
 └── pipeline/
-    └── analyzeRepo.ts          # Orchestrates discovery → parse → extract
+    └── analyzeRepo.ts          # Orchestrates profile → discovery → parse → extract
 ```
 
 ## Scripts
@@ -74,10 +84,11 @@ src/
 
 ## How it works
 
-1. **Discover** — `fast-glob` finds all `.ts` and `.tsx` files, ignoring `node_modules`, `dist`, `build`, `.next`, and other non-source directories.
-2. **Parse** — Each file is parsed into a concrete syntax tree using Tree-sitter with the appropriate grammar (TypeScript or TSX).
-3. **Extract** — An iterative depth-first traversal counts function-like AST nodes: `function_declaration`, `arrow_function`, `method_definition`, `function`, `generator_function_declaration`, and `generator_function`.
-4. **Report** — Results are aggregated into a JSON report with totals and per-file breakdowns.
+1. **Profile** — Counts files by type (`.ts`, `.tsx`, test) and computes LOC breakdowns (total, source, test) before any parsing begins.
+2. **Discover** — `fast-glob` finds all `.ts` and `.tsx` files, ignoring `node_modules`, `dist`, `build`, `.next`, and other non-source directories.
+3. **Parse** — Each file is parsed into a concrete syntax tree using Tree-sitter with the appropriate grammar (TypeScript or TSX).
+4. **Extract** — An iterative depth-first traversal counts function-like AST nodes: `function_declaration`, `arrow_function`, `method_definition`, `function`, `generator_function_declaration`, and `generator_function`.
+5. **Report** — Results are aggregated into a JSON report with profile, totals, and per-file breakdowns.
 
 ## License
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,0 +1,47 @@
+# Output Schema Reference
+
+This document describes the JSON report produced by `ts-repo-metrics`.
+
+## Top-level structure
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `repoPath` | `string` | Absolute path to the analyzed repository |
+| `filesAnalyzed` | `number` | Total number of `.ts`/`.tsx` files parsed |
+| `profile` | `RepoProfile` | File counts and LOC breakdown (see below) |
+| `totals` | `object` | Aggregate metrics across all files |
+| `totals.functions` | `number` | Total function-like nodes in the repo |
+| `perFile` | `PerFileEntry[]` | Per-file metrics (see below) |
+
+## `profile` — Repository Profiling
+
+Computed before AST analysis. Provides high-level repository statistics.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalFiles` | `number` | Total `.ts` + `.tsx` files (excluding ignored dirs) |
+| `tsFiles` | `number` | Count of `.ts` files |
+| `tsxFiles` | `number` | Count of `.tsx` files |
+| `testFiles` | `number` | Files matching `*.test.ts`, `*.spec.ts`, `*.test.tsx`, `*.spec.tsx` |
+| `totalLOC` | `number` | Total lines of code across all files |
+| `sourceLOC` | `number` | Lines of code in non-test files |
+| `testLOC` | `number` | Lines of code in test files |
+
+## `perFile` — Per-File Entry
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file` | `string` | Path relative to `repoPath` |
+| `functions` | `number` | Total function-like nodes in the file |
+| `functionsByType` | `Record<string, number>` | Breakdown by AST node type |
+
+### `functionsByType` keys
+
+| Key | Description |
+|-----|-------------|
+| `function_declaration` | Named function declarations |
+| `generator_function_declaration` | Named generator function declarations |
+| `method_definition` | Class/object methods (including getters, setters, constructors) |
+| `arrow_function` | Arrow function expressions |
+| `function` | Anonymous function expressions |
+| `generator_function` | Anonymous generator function expressions |

--- a/src/collect/fileDiscovery.ts
+++ b/src/collect/fileDiscovery.ts
@@ -7,22 +7,18 @@
  */
 
 import fg from "fast-glob";
+import { SOURCE_PATTERNS, IGNORE_PATTERNS } from "../utils/constants.js";
 
+/**
+ * Discover all TypeScript and TSX source files in a repository.
+ *
+ * @param repoPath - Absolute path to the repository root.
+ * @returns Array of absolute file paths.
+ */
 export async function discoverSourceFiles(repoPath: string) {
-  const patterns = ["**/*.ts", "**/*.tsx"];
-  const ignore = [
-    "**/node_modules/**",
-    "**/dist/**",
-    "**/build/**",
-    "**/.next/**",
-    "**/out/**",
-    "**/coverage/**",
-    "**/.git/**",
-  ];
-
-  return fg(patterns, {
+  return fg(SOURCE_PATTERNS, {
     cwd: repoPath,
     absolute: true,
-    ignore,
+    ignore: IGNORE_PATTERNS,
   });
 }

--- a/src/collect/loc.ts
+++ b/src/collect/loc.ts
@@ -2,53 +2,18 @@
  * Repository profiling module.
  *
  * Computes high-level repository statistics — file counts by type and lines
- * of code (total, source, test) — before AST analysis runs. Reuses the same
- * ignore list as file discovery so counts stay consistent.
+ * of code (total, source, test) — before AST analysis runs. Uses shared
+ * constants so ignore patterns and file classification stay consistent
+ * across all modules.
  */
 
 import { readFile } from "node:fs/promises";
 import fg from "fast-glob";
+import { SOURCE_PATTERNS, IGNORE_PATTERNS, TEST_FILE_RE } from "../utils/constants.js";
+import { countLines } from "../utils/text.js";
+import type { RepoProfile } from "../types/report.js";
 
-const SOURCE_PATTERNS = ["**/*.ts", "**/*.tsx"];
-
-const IGNORE = [
-  "**/node_modules/**",
-  "**/dist/**",
-  "**/build/**",
-  "**/.next/**",
-  "**/out/**",
-  "**/coverage/**",
-  "**/.git/**",
-];
-
-const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx)$/;
-
-/** Breakdown of file counts and lines of code for a repository. */
-export interface RepoProfile {
-  totalFiles: number;
-  tsFiles: number;
-  tsxFiles: number;
-  testFiles: number;
-  totalLOC: number;
-  sourceLOC: number;
-  testLOC: number;
-}
-
-/**
- * Count the number of newline-delimited lines in a string.
- *
- * @param text - Raw file contents.
- * @returns Line count (empty file = 0, single trailing newline not double-counted).
- */
-function countLines(text: string): number {
-  if (text.length === 0) return 0;
-  let count = 1;
-  for (let i = 0; i < text.length; i++) {
-    if (text[i] === "\n") count++;
-  }
-  if (text[text.length - 1] === "\n") count--;
-  return count;
-}
+export type { RepoProfile } from "../types/report.js";
 
 /**
  * Profile a repository's TypeScript / TSX source files.
@@ -63,7 +28,7 @@ export async function profileRepo(repoPath: string): Promise<RepoProfile> {
   const files = await fg(SOURCE_PATTERNS, {
     cwd: repoPath,
     absolute: true,
-    ignore: IGNORE,
+    ignore: IGNORE_PATTERNS,
   });
 
   let tsFiles = 0;

--- a/src/collect/loc.ts
+++ b/src/collect/loc.ts
@@ -1,0 +1,104 @@
+/**
+ * Repository profiling module.
+ *
+ * Computes high-level repository statistics — file counts by type and lines
+ * of code (total, source, test) — before AST analysis runs. Reuses the same
+ * ignore list as file discovery so counts stay consistent.
+ */
+
+import { readFile } from "node:fs/promises";
+import fg from "fast-glob";
+
+const SOURCE_PATTERNS = ["**/*.ts", "**/*.tsx"];
+
+const IGNORE = [
+  "**/node_modules/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/.next/**",
+  "**/out/**",
+  "**/coverage/**",
+  "**/.git/**",
+];
+
+const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx)$/;
+
+/** Breakdown of file counts and lines of code for a repository. */
+export interface RepoProfile {
+  totalFiles: number;
+  tsFiles: number;
+  tsxFiles: number;
+  testFiles: number;
+  totalLOC: number;
+  sourceLOC: number;
+  testLOC: number;
+}
+
+/**
+ * Count the number of newline-delimited lines in a string.
+ *
+ * @param text - Raw file contents.
+ * @returns Line count (empty file = 0, single trailing newline not double-counted).
+ */
+function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  let count = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "\n") count++;
+  }
+  if (text[text.length - 1] === "\n") count--;
+  return count;
+}
+
+/**
+ * Profile a repository's TypeScript / TSX source files.
+ *
+ * Discovers all `.ts` and `.tsx` files (excluding common non-source dirs),
+ * classifies each as source or test, and counts lines of code.
+ *
+ * @param repoPath - Absolute path to the repository root.
+ * @returns A {@link RepoProfile} with file counts and LOC breakdowns.
+ */
+export async function profileRepo(repoPath: string): Promise<RepoProfile> {
+  const files = await fg(SOURCE_PATTERNS, {
+    cwd: repoPath,
+    absolute: true,
+    ignore: IGNORE,
+  });
+
+  let tsFiles = 0;
+  let tsxFiles = 0;
+  let testFiles = 0;
+  let totalLOC = 0;
+  let sourceLOC = 0;
+  let testLOC = 0;
+
+  for (const filePath of files) {
+    const content = await readFile(filePath, "utf8");
+    const lines = countLines(content);
+    const isTest = TEST_FILE_RE.test(filePath);
+    const isTsx = filePath.endsWith(".tsx");
+
+    if (isTsx) tsxFiles++;
+    else tsFiles++;
+
+    if (isTest) {
+      testFiles++;
+      testLOC += lines;
+    } else {
+      sourceLOC += lines;
+    }
+
+    totalLOC += lines;
+  }
+
+  return {
+    totalFiles: files.length,
+    tsFiles,
+    tsxFiles,
+    testFiles,
+    totalLOC,
+    sourceLOC,
+    testLOC,
+  };
+}

--- a/src/pipeline/analyzeRepo.ts
+++ b/src/pipeline/analyzeRepo.ts
@@ -1,15 +1,16 @@
 /**
  * Repository analysis pipeline.
  *
- * Orchestrates the end-to-end flow: discovers source files, reads each one,
- * parses it with Tree-sitter, and runs every registered extractor (currently
- * function count). Returns a JSON-serializable report with aggregate totals
- * and per-file breakdowns.
+ * Orchestrates the end-to-end flow: profiles the repo (LOC and file counts),
+ * discovers source files, reads each one, parses it with Tree-sitter, and
+ * runs every registered extractor (currently function count). Returns a
+ * JSON-serializable report with aggregate totals and per-file breakdowns.
  */
 
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { discoverSourceFiles } from "../collect/fileDiscovery.js";
+import { profileRepo } from "../collect/loc.js";
 import { parseTypeScript } from "../parsing/tsParser.js";
 import { countFunctions } from "../extract/functionCount.js";
 
@@ -17,7 +18,14 @@ function flavorForFile(filePath: string): "ts" | "tsx" {
   return filePath.endsWith(".tsx") ? "tsx" : "ts";
 }
 
+/**
+ * Run the full analysis pipeline on a repository.
+ *
+ * @param repoPath - Absolute path to the repository root.
+ * @returns A JSON-serializable report with profile, totals, and per-file data.
+ */
 export async function analyzeRepo(repoPath: string) {
+  const profile = await profileRepo(repoPath);
   const files = await discoverSourceFiles(repoPath);
 
   let totalFunctions = 0;
@@ -39,6 +47,7 @@ export async function analyzeRepo(repoPath: string) {
   return {
     repoPath,
     filesAnalyzed: files.length,
+    profile,
     totals: {
       functions: totalFunctions,
     },

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared type definitions for the metrics report.
+ *
+ * All report section interfaces live here so modules can import the
+ * shapes they produce without circular dependencies.
+ */
+
+/** Breakdown of file counts and lines of code for a repository. */
+export interface RepoProfile {
+  totalFiles: number;
+  tsFiles: number;
+  tsxFiles: number;
+  testFiles: number;
+  totalLOC: number;
+  sourceLOC: number;
+  testLOC: number;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared constants used across collection and extraction modules.
+ */
+
+/** Glob patterns for TypeScript and TSX source files. */
+export const SOURCE_PATTERNS = ["**/*.ts", "**/*.tsx"];
+
+/** Directories to exclude from all file discovery and analysis. */
+export const IGNORE_PATTERNS = [
+  "**/node_modules/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/.next/**",
+  "**/out/**",
+  "**/coverage/**",
+  "**/.git/**",
+];
+
+/** Matches test files by convention: `*.test.ts`, `*.spec.ts`, `*.test.tsx`, `*.spec.tsx`. */
+export const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx)$/;

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,19 @@
+/**
+ * Text-processing utilities shared across modules.
+ */
+
+/**
+ * Count the number of newline-delimited lines in a string.
+ *
+ * @param text - Raw file contents.
+ * @returns Line count (empty file = 0, single trailing newline not double-counted).
+ */
+export function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  let count = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "\n") count++;
+  }
+  if (text[text.length - 1] === "\n") count--;
+  return count;
+}


### PR DESCRIPTION
## Summary

Closes #1

- Adds `src/collect/loc.ts` — a profiling module that counts files by type (`.ts`, `.tsx`, test) and computes LOC breakdowns (total, source, test) before AST analysis runs
- Integrates `profileRepo()` into the `analyzeRepo()` pipeline so the `profile` section appears in the JSON report
- Creates `docs/SCHEMA.md` with full field reference for the output schema
- Updates README with profile in example output, project structure, and "How it works"

## Test plan

- [x] Run `npm run dev -- /path/to/repo` and verify `profile` section appears with correct numbers
- [x] Self-analysis: 6 `.ts` files, 0 `.tsx`, 0 test files, 278 total LOC = 278 source LOC
- [ ] Test with a repo containing `.test.ts` files to verify test file classification
- [ ] Test with a repo containing `.tsx` files to verify TSX counting

Made with [Cursor](https://cursor.com)