### PR TITLE
Add Function Length and Nesting Depth Metrics

### DIFF
--- a/.cursor/rules/shared-code-organization.mdc
+++ b/.cursor/rules/shared-code-organization.mdc
@@ -1,0 +1,47 @@
+---
+description: Enforce shared placement of reusable utilities, constants, and types
+globs: src/**/*.ts
+alwaysApply: false
+---
+
+# Shared Code Organization
+
+Reusable utilities, constants, and types must NOT live in individual feature files. Place them in the designated shared locations:
+
+| Kind | Location | Example |
+|------|----------|---------|
+| Constants (patterns, thresholds, regexes) | `src/utils/constants.ts` | `SOURCE_PATTERNS`, `IGNORE_PATTERNS`, `TEST_FILE_RE` |
+| Utility functions (pure helpers) | `src/utils/<topic>.ts` | `countLines()` in `src/utils/text.ts` |
+| Shared interfaces / types | `src/types/report.ts` | `RepoProfile`, `FunctionDetail` |
+
+## Rules
+
+1. **Before adding a constant, type, or helper to a feature file**, check whether it already exists in `src/utils/` or `src/types/`. If it does, import it.
+2. **If a value is used by more than one module** (or is likely to be), define it in the shared location from the start — not inline.
+3. **Feature-specific private helpers** that are only used inside one file may remain local. Mark them with a leading underscore or keep them unexported.
+4. **Re-exports for convenience** are allowed (e.g., `src/types/report.ts` re-exporting from an extractor), but the canonical definition should live in the shared file.
+
+## Examples
+
+```typescript
+// ❌ BAD — reusable constant defined in a feature file
+// src/extract/functionMetrics.ts
+const FUNCTION_NODE_TYPES = new Set(["function_declaration", ...]);
+
+// ✅ GOOD — shared constant imported from utils
+// src/utils/constants.ts
+export const FUNCTION_NODE_TYPES = new Set(["function_declaration", ...]);
+
+// src/extract/functionMetrics.ts
+import { FUNCTION_NODE_TYPES } from "../utils/constants.js";
+```
+
+```typescript
+// ❌ BAD — interface defined in a feature module that others need
+// src/collect/loc.ts
+export interface RepoProfile { ... }
+
+// ✅ GOOD — interface in shared types
+// src/types/report.ts
+export interface RepoProfile { ... }
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ts-repo-metrics
 
-A TypeScript CLI tool that statically analyzes TypeScript and TSX repositories using [Tree-sitter](https://tree-sitter.github.io/tree-sitter/), producing a JSON report with repository profiling (LOC and file type breakdown), function counts, and per-file breakdowns by function type.
+A TypeScript CLI tool that statically analyzes TypeScript and TSX repositories using [Tree-sitter](https://tree-sitter.github.io/tree-sitter/), producing a JSON report with repository profiling (LOC and file type breakdown), function counts, per-function structural metrics (line length, nesting depth, parameter count), and per-file breakdowns.
 
 ## Prerequisites
 
@@ -41,18 +41,31 @@ npm run dev -- /absolute/path/to/target/repo
   "totals": {
     "functions": 7
   },
+  "functionMetricsSummary": {
+    "totalFunctions": 7,
+    "averageLength": 8.6,
+    "medianLength": 7,
+    "maxNestingDepth": 1,
+    "longFunctionPercentage": 0
+  },
   "perFile": [
     {
       "file": "src/cli.ts",
       "functions": 2,
       "functionsByType": {
         "function_declaration": 1,
-        "arrow_function": 1,
-        "method_definition": 0,
-        "generator_function_declaration": 0,
-        "function": 0,
-        "generator_function": 0
-      }
+        "arrow_function": 1
+      },
+      "functionMetrics": [
+        {
+          "name": "main",
+          "type": "function_declaration",
+          "startLine": 13,
+          "lines": 9,
+          "maxNestingDepth": 1,
+          "parameterCount": 0
+        }
+      ]
     }
   ]
 }
@@ -69,7 +82,8 @@ src/
 ├── parsing/
 │   └── tsParser.ts             # Tree-sitter wrapper (TS & TSX grammars)
 ├── extract/
-│   └── functionCount.ts        # Counts functions by AST node type
+│   ├── functionCount.ts        # Counts functions by AST node type
+│   └── functionMetrics.ts      # Per-function line count, nesting depth, params
 └── pipeline/
     └── analyzeRepo.ts          # Orchestrates profile → discovery → parse → extract
 ```
@@ -87,8 +101,10 @@ src/
 1. **Profile** — Counts files by type (`.ts`, `.tsx`, test) and computes LOC breakdowns (total, source, test) before any parsing begins.
 2. **Discover** — `fast-glob` finds all `.ts` and `.tsx` files, ignoring `node_modules`, `dist`, `build`, `.next`, and other non-source directories.
 3. **Parse** — Each file is parsed into a concrete syntax tree using Tree-sitter with the appropriate grammar (TypeScript or TSX).
-4. **Extract** — An iterative depth-first traversal counts function-like AST nodes: `function_declaration`, `arrow_function`, `method_definition`, `function`, `generator_function_declaration`, and `generator_function`.
-5. **Report** — Results are aggregated into a JSON report with profile, totals, and per-file breakdowns.
+4. **Extract** — Extractors run on each parsed tree:
+   - **Function count** — counts function-like AST nodes by type.
+   - **Function metrics** — computes line count, max nesting depth, and parameter count per function.
+5. **Report** — Results are aggregated into a JSON report with profile, function metrics summary, totals, and per-file breakdowns.
 
 ## License
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -11,6 +11,7 @@ This document describes the JSON report produced by `ts-repo-metrics`.
 | `profile` | `RepoProfile` | File counts and LOC breakdown (see below) |
 | `totals` | `object` | Aggregate metrics across all files |
 | `totals.functions` | `number` | Total function-like nodes in the repo |
+| `functionMetricsSummary` | `FunctionMetricsSummary` | Repo-wide function structural metrics (see below) |
 | `perFile` | `PerFileEntry[]` | Per-file metrics (see below) |
 
 ## `profile` — Repository Profiling
@@ -27,6 +28,18 @@ Computed before AST analysis. Provides high-level repository statistics.
 | `sourceLOC` | `number` | Lines of code in non-test files |
 | `testLOC` | `number` | Lines of code in test files |
 
+## `functionMetricsSummary` — Repo-Wide Function Metrics
+
+Aggregated structural metrics across all functions in the repository.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalFunctions` | `number` | Total function-like nodes across all files |
+| `averageLength` | `number` | Mean line count across all functions |
+| `medianLength` | `number` | Median line count across all functions |
+| `maxNestingDepth` | `number` | Deepest nesting level found in any function |
+| `longFunctionPercentage` | `number` | Percentage of functions exceeding 50 lines |
+
 ## `perFile` — Per-File Entry
 
 | Field | Type | Description |
@@ -34,6 +47,18 @@ Computed before AST analysis. Provides high-level repository statistics.
 | `file` | `string` | Path relative to `repoPath` |
 | `functions` | `number` | Total function-like nodes in the file |
 | `functionsByType` | `Record<string, number>` | Breakdown by AST node type |
+| `functionMetrics` | `FunctionDetail[]` | Per-function structural metrics (see below) |
+
+### `FunctionDetail` — Per-Function Metrics
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Function name, or `"(anonymous)"` |
+| `type` | `string` | AST node type (e.g., `function_declaration`, `arrow_function`) |
+| `startLine` | `number` | 1-based line number where the function starts |
+| `lines` | `number` | Total line count of the function |
+| `maxNestingDepth` | `number` | Deepest nesting of control flow structures (if/for/while/do/switch/try) |
+| `parameterCount` | `number` | Number of declared parameters |
 
 ### `functionsByType` keys
 

--- a/src/extract/functionCount.ts
+++ b/src/extract/functionCount.ts
@@ -7,20 +7,10 @@
  */
 
 import type { SyntaxNode } from "tree-sitter";
+import { FUNCTION_NODE_TYPES } from "../utils/constants.js";
+import type { FunctionCounts } from "../types/report.js";
 
-const FUNCTION_NODE_TYPES = new Set([
-  "function_declaration",
-  "generator_function_declaration",
-  "method_definition",
-  "arrow_function",
-  "function",
-  "generator_function",
-]);
-
-export interface FunctionCounts {
-  total: number;
-  byType: Record<string, number>;
-}
+export type { FunctionCounts } from "../types/report.js";
 
 export function countFunctions(root: SyntaxNode): FunctionCounts {
   let total = 0;

--- a/src/extract/functionMetrics.ts
+++ b/src/extract/functionMetrics.ts
@@ -2,57 +2,28 @@
  * Function-level structural metrics extractor.
  *
  * For every function-like AST node in a file, computes line count, maximum
- * nesting depth, and parameter count. Also produces a repo-level summary
+ * nesting depth, and parameter count. Also produces a file-level summary
  * with averages, medians, maximums, and percentages.
  */
 
 import type { SyntaxNode } from "tree-sitter";
+import {
+  FUNCTION_NODE_TYPES,
+  NESTING_NODE_TYPES,
+  LONG_FUNCTION_THRESHOLD,
+} from "../utils/constants.js";
+import { median } from "../utils/math.js";
+import type {
+  FunctionDetail,
+  FunctionMetricsSummary,
+  FunctionMetricsResult,
+} from "../types/report.js";
 
-const FUNCTION_NODE_TYPES = new Set([
-  "function_declaration",
-  "generator_function_declaration",
-  "method_definition",
-  "arrow_function",
-  "function",
-  "generator_function",
-]);
-
-const NESTING_NODE_TYPES = new Set([
-  "if_statement",
-  "for_statement",
-  "for_in_statement",
-  "while_statement",
-  "do_statement",
-  "switch_statement",
-  "try_statement",
-]);
-
-const LONG_FUNCTION_THRESHOLD = 50;
-
-/** Metrics for a single function. */
-export interface FunctionDetail {
-  name: string;
-  type: string;
-  startLine: number;
-  lines: number;
-  maxNestingDepth: number;
-  parameterCount: number;
-}
-
-/** Aggregated function metrics for an entire repository. */
-export interface FunctionMetricsSummary {
-  totalFunctions: number;
-  averageLength: number;
-  medianLength: number;
-  maxNestingDepth: number;
-  longFunctionPercentage: number;
-}
-
-/** Combined result: per-function details and repo-level summary. */
-export interface FunctionMetricsResult {
-  functions: FunctionDetail[];
-  summary: FunctionMetricsSummary;
-}
+export type {
+  FunctionDetail,
+  FunctionMetricsSummary,
+  FunctionMetricsResult,
+} from "../types/report.js";
 
 /**
  * Derive a human-readable name for a function node.
@@ -121,20 +92,6 @@ function maxNesting(node: SyntaxNode, currentDepth: number): number {
     }
   }
   return max;
-}
-
-/**
- * Compute the median of a sorted numeric array.
- *
- * @param sorted - Array of numbers in ascending order.
- * @returns The median value, or 0 for an empty array.
- */
-function median(sorted: number[]): number {
-  if (sorted.length === 0) return 0;
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0
-    ? (sorted[mid - 1]! + sorted[mid]!) / 2
-    : sorted[mid]!;
 }
 
 /**

--- a/src/extract/functionMetrics.ts
+++ b/src/extract/functionMetrics.ts
@@ -1,0 +1,197 @@
+/**
+ * Function-level structural metrics extractor.
+ *
+ * For every function-like AST node in a file, computes line count, maximum
+ * nesting depth, and parameter count. Also produces a repo-level summary
+ * with averages, medians, maximums, and percentages.
+ */
+
+import type { SyntaxNode } from "tree-sitter";
+
+const FUNCTION_NODE_TYPES = new Set([
+  "function_declaration",
+  "generator_function_declaration",
+  "method_definition",
+  "arrow_function",
+  "function",
+  "generator_function",
+]);
+
+const NESTING_NODE_TYPES = new Set([
+  "if_statement",
+  "for_statement",
+  "for_in_statement",
+  "while_statement",
+  "do_statement",
+  "switch_statement",
+  "try_statement",
+]);
+
+const LONG_FUNCTION_THRESHOLD = 50;
+
+/** Metrics for a single function. */
+export interface FunctionDetail {
+  name: string;
+  type: string;
+  startLine: number;
+  lines: number;
+  maxNestingDepth: number;
+  parameterCount: number;
+}
+
+/** Aggregated function metrics for an entire repository. */
+export interface FunctionMetricsSummary {
+  totalFunctions: number;
+  averageLength: number;
+  medianLength: number;
+  maxNestingDepth: number;
+  longFunctionPercentage: number;
+}
+
+/** Combined result: per-function details and repo-level summary. */
+export interface FunctionMetricsResult {
+  functions: FunctionDetail[];
+  summary: FunctionMetricsSummary;
+}
+
+/**
+ * Derive a human-readable name for a function node.
+ *
+ * @param node - A function-like AST node.
+ * @returns The function name, or "(anonymous)" if none can be determined.
+ */
+function getFunctionName(node: SyntaxNode): string {
+  const nameChild = node.childForFieldName("name");
+  if (nameChild) return nameChild.text;
+
+  if (node.parent?.type === "variable_declarator") {
+    const id = node.parent.childForFieldName("name");
+    if (id) return id.text;
+  }
+
+  if (node.parent?.type === "pair") {
+    const key = node.parent.childForFieldName("key");
+    if (key) return key.text;
+  }
+
+  return "(anonymous)";
+}
+
+/**
+ * Count parameters of a function node.
+ *
+ * @param node - A function-like AST node.
+ * @returns Number of declared parameters.
+ */
+function countParameters(node: SyntaxNode): number {
+  const params = node.childForFieldName("parameters");
+  if (!params) return 0;
+  let count = 0;
+  for (let i = 0; i < params.namedChildCount; i++) {
+    const child = params.namedChild(i);
+    if (child && (child.type === "required_parameter" ||
+                  child.type === "optional_parameter" ||
+                  child.type === "rest_parameter" ||
+                  child.type === "identifier")) {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Compute the maximum nesting depth within a subtree.
+ * Only counts nesting structures (if, for, while, do, switch, try).
+ *
+ * @param node - Root of the subtree to measure.
+ * @param currentDepth - Depth accumulated from parent nesting nodes.
+ * @returns The deepest nesting level found.
+ */
+function maxNesting(node: SyntaxNode, currentDepth: number): number {
+  const depth = NESTING_NODE_TYPES.has(node.type)
+    ? currentDepth + 1
+    : currentDepth;
+
+  let max = depth;
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const child = node.namedChild(i);
+    if (child) {
+      const childMax = maxNesting(child, depth);
+      if (childMax > max) max = childMax;
+    }
+  }
+  return max;
+}
+
+/**
+ * Compute the median of a sorted numeric array.
+ *
+ * @param sorted - Array of numbers in ascending order.
+ * @returns The median value, or 0 for an empty array.
+ */
+function median(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1]! + sorted[mid]!) / 2
+    : sorted[mid]!;
+}
+
+/**
+ * Extract structural metrics for every function in a syntax tree.
+ *
+ * @param root - The root node of a Tree-sitter syntax tree.
+ * @returns Per-function details and a repo-level summary.
+ */
+export function extractFunctionMetrics(root: SyntaxNode): FunctionMetricsResult {
+  const functions: FunctionDetail[] = [];
+
+  const stack: SyntaxNode[] = [root];
+  while (stack.length) {
+    const node = stack.pop()!;
+
+    if (FUNCTION_NODE_TYPES.has(node.type)) {
+      const lines = node.endPosition.row - node.startPosition.row + 1;
+      functions.push({
+        name: getFunctionName(node),
+        type: node.type,
+        startLine: node.startPosition.row + 1,
+        lines,
+        maxNestingDepth: maxNesting(node, 0),
+        parameterCount: countParameters(node),
+      });
+    }
+
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child) stack.push(child);
+    }
+  }
+
+  const lengths = functions.map((f) => f.lines).sort((a, b) => a - b);
+  const totalFunctions = functions.length;
+  const averageLength =
+    totalFunctions > 0
+      ? Math.round((lengths.reduce((a, b) => a + b, 0) / totalFunctions) * 10) / 10
+      : 0;
+  const maxNestingDepth = functions.reduce(
+    (max, f) => Math.max(max, f.maxNestingDepth),
+    0,
+  );
+  const longCount = functions.filter((f) => f.lines > LONG_FUNCTION_THRESHOLD).length;
+  const longFunctionPercentage =
+    totalFunctions > 0
+      ? Math.round((longCount / totalFunctions) * 1000) / 10
+      : 0;
+
+  return {
+    functions,
+    summary: {
+      totalFunctions,
+      averageLength,
+      medianLength: median(lengths),
+      maxNestingDepth,
+      longFunctionPercentage,
+    },
+  };
+}

--- a/src/pipeline/analyzeRepo.ts
+++ b/src/pipeline/analyzeRepo.ts
@@ -14,7 +14,9 @@ import { profileRepo } from "../collect/loc.js";
 import { parseTypeScript } from "../parsing/tsParser.js";
 import { countFunctions } from "../extract/functionCount.js";
 import { extractFunctionMetrics } from "../extract/functionMetrics.js";
-import type { FunctionDetail, FunctionMetricsSummary } from "../extract/functionMetrics.js";
+import { LONG_FUNCTION_THRESHOLD } from "../utils/constants.js";
+import { median } from "../utils/math.js";
+import type { FunctionDetail, FunctionMetricsSummary } from "../types/report.js";
 
 function flavorForFile(filePath: string): "ts" | "tsx" {
   return filePath.endsWith(".tsx") ? "tsx" : "ts";
@@ -56,20 +58,16 @@ export async function analyzeRepo(repoPath: string) {
   }
 
   const lengths = allFunctionDetails.map((f) => f.lines).sort((a, b) => a - b);
-  const medianLength = lengths.length === 0 ? 0
-    : lengths.length % 2 === 0
-      ? (lengths[lengths.length / 2 - 1]! + lengths[lengths.length / 2]!) / 2
-      : lengths[Math.floor(lengths.length / 2)]!;
 
   const functionMetricsSummary: FunctionMetricsSummary = {
     totalFunctions,
     averageLength: totalFunctions > 0
       ? Math.round((lengths.reduce((a, b) => a + b, 0) / totalFunctions) * 10) / 10
       : 0,
-    medianLength,
+    medianLength: median(lengths),
     maxNestingDepth: allFunctionDetails.reduce((max, f) => Math.max(max, f.maxNestingDepth), 0),
     longFunctionPercentage: totalFunctions > 0
-      ? Math.round((allFunctionDetails.filter((f) => f.lines > 50).length / totalFunctions) * 1000) / 10
+      ? Math.round((allFunctionDetails.filter((f) => f.lines > LONG_FUNCTION_THRESHOLD).length / totalFunctions) * 1000) / 10
       : 0,
   };
 

--- a/src/pipeline/analyzeRepo.ts
+++ b/src/pipeline/analyzeRepo.ts
@@ -13,6 +13,8 @@ import { discoverSourceFiles } from "../collect/fileDiscovery.js";
 import { profileRepo } from "../collect/loc.js";
 import { parseTypeScript } from "../parsing/tsParser.js";
 import { countFunctions } from "../extract/functionCount.js";
+import { extractFunctionMetrics } from "../extract/functionMetrics.js";
+import type { FunctionDetail, FunctionMetricsSummary } from "../extract/functionMetrics.js";
 
 function flavorForFile(filePath: string): "ts" | "tsx" {
   return filePath.endsWith(".tsx") ? "tsx" : "ts";
@@ -29,20 +31,47 @@ export async function analyzeRepo(repoPath: string) {
   const files = await discoverSourceFiles(repoPath);
 
   let totalFunctions = 0;
-  const perFile: Array<{ file: string; functions: number; functionsByType: Record<string, number> }> = [];
+  const allFunctionDetails: FunctionDetail[] = [];
+  const perFile: Array<{
+    file: string;
+    functions: number;
+    functionsByType: Record<string, number>;
+    functionMetrics: FunctionDetail[];
+  }> = [];
 
   for (const filePath of files) {
     const code = await readFile(filePath, "utf8");
     const tree = parseTypeScript(code, flavorForFile(filePath));
     const fnCount = countFunctions(tree.rootNode);
+    const fnMetrics = extractFunctionMetrics(tree.rootNode);
 
     totalFunctions += fnCount.total;
+    allFunctionDetails.push(...fnMetrics.functions);
     perFile.push({
       file: path.relative(repoPath, filePath),
       functions: fnCount.total,
       functionsByType: fnCount.byType,
+      functionMetrics: fnMetrics.functions,
     });
   }
+
+  const lengths = allFunctionDetails.map((f) => f.lines).sort((a, b) => a - b);
+  const medianLength = lengths.length === 0 ? 0
+    : lengths.length % 2 === 0
+      ? (lengths[lengths.length / 2 - 1]! + lengths[lengths.length / 2]!) / 2
+      : lengths[Math.floor(lengths.length / 2)]!;
+
+  const functionMetricsSummary: FunctionMetricsSummary = {
+    totalFunctions,
+    averageLength: totalFunctions > 0
+      ? Math.round((lengths.reduce((a, b) => a + b, 0) / totalFunctions) * 10) / 10
+      : 0,
+    medianLength,
+    maxNestingDepth: allFunctionDetails.reduce((max, f) => Math.max(max, f.maxNestingDepth), 0),
+    longFunctionPercentage: totalFunctions > 0
+      ? Math.round((allFunctionDetails.filter((f) => f.lines > 50).length / totalFunctions) * 1000) / 10
+      : 0,
+  };
 
   return {
     repoPath,
@@ -51,6 +80,7 @@ export async function analyzeRepo(repoPath: string) {
     totals: {
       functions: totalFunctions,
     },
+    functionMetricsSummary,
     perFile,
   };
 }

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -16,9 +16,33 @@ export interface RepoProfile {
   testLOC: number;
 }
 
-/** Re-export function metric types from the extractor for convenience. */
-export type {
-  FunctionDetail,
-  FunctionMetricsSummary,
-  FunctionMetricsResult,
-} from "../extract/functionMetrics.js";
+/** Count of function-like AST nodes, with a per-type breakdown. */
+export interface FunctionCounts {
+  total: number;
+  byType: Record<string, number>;
+}
+
+/** Metrics for a single function. */
+export interface FunctionDetail {
+  name: string;
+  type: string;
+  startLine: number;
+  lines: number;
+  maxNestingDepth: number;
+  parameterCount: number;
+}
+
+/** Aggregated function metrics for an entire repository. */
+export interface FunctionMetricsSummary {
+  totalFunctions: number;
+  averageLength: number;
+  medianLength: number;
+  maxNestingDepth: number;
+  longFunctionPercentage: number;
+}
+
+/** Combined result: per-function details and file-level summary. */
+export interface FunctionMetricsResult {
+  functions: FunctionDetail[];
+  summary: FunctionMetricsSummary;
+}

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -15,3 +15,10 @@ export interface RepoProfile {
   sourceLOC: number;
   testLOC: number;
 }
+
+/** Re-export function metric types from the extractor for convenience. */
+export type {
+  FunctionDetail,
+  FunctionMetricsSummary,
+  FunctionMetricsResult,
+} from "../extract/functionMetrics.js";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,6 +2,10 @@
  * Shared constants used across collection and extraction modules.
  */
 
+/* ------------------------------------------------------------------ */
+/*  File discovery                                                     */
+/* ------------------------------------------------------------------ */
+
 /** Glob patterns for TypeScript and TSX source files. */
 export const SOURCE_PATTERNS = ["**/*.ts", "**/*.tsx"];
 
@@ -18,3 +22,35 @@ export const IGNORE_PATTERNS = [
 
 /** Matches test files by convention: `*.test.ts`, `*.spec.ts`, `*.test.tsx`, `*.spec.tsx`. */
 export const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx)$/;
+
+/* ------------------------------------------------------------------ */
+/*  AST node classification                                            */
+/* ------------------------------------------------------------------ */
+
+/** Tree-sitter node types that represent function-like constructs. */
+export const FUNCTION_NODE_TYPES = new Set([
+  "function_declaration",
+  "generator_function_declaration",
+  "method_definition",
+  "arrow_function",
+  "function",
+  "generator_function",
+]);
+
+/** Tree-sitter node types that introduce a nesting level for depth calculation. */
+export const NESTING_NODE_TYPES = new Set([
+  "if_statement",
+  "for_statement",
+  "for_in_statement",
+  "while_statement",
+  "do_statement",
+  "switch_statement",
+  "try_statement",
+]);
+
+/* ------------------------------------------------------------------ */
+/*  Thresholds                                                         */
+/* ------------------------------------------------------------------ */
+
+/** Functions exceeding this many lines are classified as "long". */
+export const LONG_FUNCTION_THRESHOLD = 50;

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,17 @@
+/**
+ * Numeric utilities shared across extraction and pipeline modules.
+ */
+
+/**
+ * Compute the median of a sorted numeric array.
+ *
+ * @param sorted - Array of numbers in ascending order.
+ * @returns The median value, or 0 for an empty array.
+ */
+export function median(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1]! + sorted[mid]!) / 2
+    : sorted[mid]!;
+}


### PR DESCRIPTION
## Summary

Closes #2

- Adds `src/extract/functionMetrics.ts` — extracts per-function structural metrics: line count, max nesting depth (if/for/while/do/switch/try), and parameter count
- Derives a repo-level `functionMetricsSummary` with average length, median length, max nesting depth, and long function percentage (> 50 lines)
- Per-file entries now include a `functionMetrics` array with full detail for each function
- Types added to `src/types/report.ts`
- `docs/SCHEMA.md` updated with `functionMetricsSummary` and `FunctionDetail` field references
- README updated with new fields in example output and project structure

## Test plan

- [x] Run `npm run dev -- /path/to/repo` and verify `functionMetricsSummary` and per-file `functionMetrics` appear
- [x] Self-analysis: 24 functions, avg length 11.5, median 4.5, max nesting 3, 8.3% long
- [ ] Test with a file containing a deeply nested function (3+ levels) to verify nesting count
- [ ] Test with a multi-param arrow function to verify parameter count

Made with [Cursor](https://cursor.com)