### PR TITLE
Add Structural Code Smell Detection

### DIFF
--- a/src/extract/smells.ts
+++ b/src/extract/smells.ts
@@ -1,0 +1,196 @@
+/**
+ * Structural code smell detectors.
+ *
+ * Each detector is a standalone function that walks an AST and returns a count.
+ * Thresholds are imported from shared constants so they're easy to tune.
+ *
+ * Detected smells:
+ * - Long functions (> LONG_FUNCTION_THRESHOLD lines)
+ * - Deep nesting (> DEEP_NESTING_THRESHOLD levels)
+ * - Long parameter lists (> LONG_PARAM_LIST_THRESHOLD params)
+ * - Empty catch blocks (catch with an empty statement_block body)
+ * - Console usage (console.log / console.warn / console.error)
+ */
+
+import type { SyntaxNode } from "tree-sitter";
+import {
+  FUNCTION_NODE_TYPES,
+  NESTING_NODE_TYPES,
+  LONG_FUNCTION_THRESHOLD,
+  DEEP_NESTING_THRESHOLD,
+  LONG_PARAM_LIST_THRESHOLD,
+} from "../utils/constants.js";
+import type { SmellCounts } from "../types/report.js";
+
+export type { SmellCounts } from "../types/report.js";
+
+/**
+ * Count functions that exceed the long-function line threshold.
+ *
+ * @param root - Root node of a Tree-sitter syntax tree.
+ * @returns Number of functions longer than LONG_FUNCTION_THRESHOLD lines.
+ */
+export function detectLongFunctions(root: SyntaxNode): number {
+  let count = 0;
+  const stack: SyntaxNode[] = [root];
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (FUNCTION_NODE_TYPES.has(node.type)) {
+      const lines = node.endPosition.row - node.startPosition.row + 1;
+      if (lines > LONG_FUNCTION_THRESHOLD) count++;
+    }
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child) stack.push(child);
+    }
+  }
+  return count;
+}
+
+/**
+ * Count functions whose maximum nesting depth exceeds the threshold.
+ *
+ * @param root - Root node of a Tree-sitter syntax tree.
+ * @returns Number of functions with nesting deeper than DEEP_NESTING_THRESHOLD.
+ */
+export function detectDeepNesting(root: SyntaxNode): number {
+  let count = 0;
+
+  function maxNesting(node: SyntaxNode, depth: number): number {
+    const d = NESTING_NODE_TYPES.has(node.type) ? depth + 1 : depth;
+    let max = d;
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child) {
+        const cm = maxNesting(child, d);
+        if (cm > max) max = cm;
+      }
+    }
+    return max;
+  }
+
+  const stack: SyntaxNode[] = [root];
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (FUNCTION_NODE_TYPES.has(node.type)) {
+      if (maxNesting(node, 0) > DEEP_NESTING_THRESHOLD) count++;
+    }
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child) stack.push(child);
+    }
+  }
+  return count;
+}
+
+/**
+ * Count functions with more parameters than the threshold.
+ *
+ * @param root - Root node of a Tree-sitter syntax tree.
+ * @returns Number of functions with more than LONG_PARAM_LIST_THRESHOLD parameters.
+ */
+export function detectLongParameterLists(root: SyntaxNode): number {
+  let count = 0;
+  const stack: SyntaxNode[] = [root];
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (FUNCTION_NODE_TYPES.has(node.type)) {
+      const params = node.childForFieldName("parameters");
+      if (params) {
+        let pCount = 0;
+        for (let i = 0; i < params.namedChildCount; i++) {
+          const child = params.namedChild(i);
+          if (
+            child &&
+            (child.type === "required_parameter" ||
+              child.type === "optional_parameter" ||
+              child.type === "rest_parameter" ||
+              child.type === "identifier")
+          ) {
+            pCount++;
+          }
+        }
+        if (pCount > LONG_PARAM_LIST_THRESHOLD) count++;
+      }
+    }
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child) stack.push(child);
+    }
+  }
+  return count;
+}
+
+/**
+ * Count empty catch blocks (`catch (e) {}`).
+ *
+ * @param root - Root node of a Tree-sitter syntax tree.
+ * @returns Number of catch clauses with an empty body.
+ */
+export function detectEmptyCatchBlocks(root: SyntaxNode): number {
+  let count = 0;
+  const stack: SyntaxNode[] = [root];
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (node.type === "catch_clause") {
+      const body = node.childForFieldName("body");
+      if (body && body.namedChildCount === 0) count++;
+    }
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child) stack.push(child);
+    }
+  }
+  return count;
+}
+
+/**
+ * Count console.log, console.warn, and console.error calls.
+ *
+ * @param root - Root node of a Tree-sitter syntax tree.
+ * @returns Number of console logging calls found.
+ */
+export function detectConsoleLogs(root: SyntaxNode): number {
+  const CONSOLE_METHODS = new Set(["log", "warn", "error"]);
+  let count = 0;
+  const stack: SyntaxNode[] = [root];
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (node.type === "call_expression") {
+      const fn = node.childForFieldName("function");
+      if (fn?.type === "member_expression") {
+        const obj = fn.childForFieldName("object");
+        const prop = fn.childForFieldName("property");
+        if (
+          obj?.type === "identifier" &&
+          obj.text === "console" &&
+          prop &&
+          CONSOLE_METHODS.has(prop.text)
+        ) {
+          count++;
+        }
+      }
+    }
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child) stack.push(child);
+    }
+  }
+  return count;
+}
+
+/**
+ * Run all smell detectors on a syntax tree and return aggregated counts.
+ *
+ * @param root - Root node of a Tree-sitter syntax tree.
+ * @returns Combined smell counts for the file.
+ */
+export function detectSmells(root: SyntaxNode): SmellCounts {
+  return {
+    longFunctions: detectLongFunctions(root),
+    deepNesting: detectDeepNesting(root),
+    longParameterLists: detectLongParameterLists(root),
+    emptyCatchBlocks: detectEmptyCatchBlocks(root),
+    consoleLogs: detectConsoleLogs(root),
+  };
+}

--- a/src/pipeline/analyzeRepo.ts
+++ b/src/pipeline/analyzeRepo.ts
@@ -15,6 +15,7 @@ import { parseTypeScript } from "../parsing/tsParser.js";
 import { countFunctions } from "../extract/functionCount.js";
 import { extractFunctionMetrics } from "../extract/functionMetrics.js";
 import { computeComplexity, summarizeComplexity } from "../extract/complexity.js";
+import { detectSmells } from "../extract/smells.js";
 import { LONG_FUNCTION_THRESHOLD } from "../utils/constants.js";
 import { median } from "../utils/math.js";
 import type {
@@ -22,6 +23,7 @@ import type {
   FunctionMetricsSummary,
   FunctionComplexity,
   ComplexitySummary,
+  SmellCounts,
 } from "../types/report.js";
 
 function flavorForFile(filePath: string): "ts" | "tsx" {
@@ -41,6 +43,13 @@ export async function analyzeRepo(repoPath: string) {
   let totalFunctions = 0;
   const allFunctionDetails: FunctionDetail[] = [];
   const allComplexities: FunctionComplexity[] = [];
+  const totalSmells: SmellCounts = {
+    longFunctions: 0,
+    deepNesting: 0,
+    longParameterLists: 0,
+    emptyCatchBlocks: 0,
+    consoleLogs: 0,
+  };
   const perFile: Array<{
     file: string;
     functions: number;
@@ -55,10 +64,16 @@ export async function analyzeRepo(repoPath: string) {
     const fnCount = countFunctions(tree.rootNode);
     const fnMetrics = extractFunctionMetrics(tree.rootNode);
     const fileComplexity = computeComplexity(tree.rootNode);
+    const fileSmells = detectSmells(tree.rootNode);
 
     totalFunctions += fnCount.total;
     allFunctionDetails.push(...fnMetrics.functions);
     allComplexities.push(...fileComplexity);
+
+    for (const key of Object.keys(totalSmells) as (keyof SmellCounts)[]) {
+      totalSmells[key] += fileSmells[key];
+    }
+
     perFile.push({
       file: path.relative(repoPath, filePath),
       functions: fnCount.total,
@@ -93,6 +108,7 @@ export async function analyzeRepo(repoPath: string) {
     },
     functionMetricsSummary,
     complexity: complexitySummary,
+    smells: totalSmells,
     perFile,
   };
 }

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -61,3 +61,12 @@ export interface ComplexitySummary {
   max: number;
   highComplexityFunctions: number;
 }
+
+/** Aggregated code smell counts across the repository. */
+export interface SmellCounts {
+  longFunctions: number;
+  deepNesting: number;
+  longParameterLists: number;
+  emptyCatchBlocks: number;
+  consoleLogs: number;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -58,6 +58,12 @@ export const LONG_FUNCTION_THRESHOLD = 50;
 /** Functions with cyclomatic complexity above this are "high complexity". */
 export const HIGH_COMPLEXITY_THRESHOLD = 10;
 
+/** Functions nested deeper than this level are flagged as a "deep nesting" smell. */
+export const DEEP_NESTING_THRESHOLD = 4;
+
+/** Functions with more parameters than this are flagged as "long parameter list". */
+export const LONG_PARAM_LIST_THRESHOLD = 4;
+
 /**
  * Tree-sitter node types that add one branch point to cyclomatic complexity.
  * Logical operators (`&&`, `||`) are handled separately via binary_expression inspection.


### PR DESCRIPTION
## Summary
Closes #4

- 5 independent smell detectors in `src/extract/smells.ts`
- Thresholds: long functions > 50 LOC, deep nesting > 4 levels, long params > 4
- Repo-level `smells` object aggregated across all files
- Constants and types in shared locations

## Test plan
- [x] Self-analysis: 2 long functions, 1 deep nesting, 0 long param lists, 0 empty catches, 3 console logs

Made with [Cursor](https://cursor.com)