### PR TITLE
Add Git History Metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "fast-glob": "^3.3.3",
         "jscpd": "^4.0.8",
+        "simple-git": "^3.31.1",
         "tree-sitter": "^0.21.1",
         "tree-sitter-typescript": "^0.23.2"
       },
@@ -578,6 +579,21 @@
         "spark-md5": "^3.0.2"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -807,6 +823,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/doctypes": {
@@ -1397,6 +1430,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/node-addon-api": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
@@ -1769,6 +1808,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/simple-git": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.31.1.tgz",
+      "integrity": "sha512-oiWP4Q9+kO8q9hHqkX35uuHmxiEbZNTrZ5IPxgMGrJwN76pzjm/jabkZO0ItEcqxAincqGAzL3QHSaHt4+knBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
     },
     "node_modules/spark-md5": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "fast-glob": "^3.3.3",
     "jscpd": "^4.0.8",
+    "simple-git": "^3.31.1",
     "tree-sitter": "^0.21.1",
     "tree-sitter-typescript": "^0.23.2"
   },

--- a/src/collect/gitMetrics.ts
+++ b/src/collect/gitMetrics.ts
@@ -1,0 +1,89 @@
+/**
+ * Git history metrics collector.
+ *
+ * Uses simple-git to extract commit-level statistics: total commits,
+ * median and average commit size (lines changed), large commit ratio
+ * (> 500 LOC), and commit frequency (commits per week over the last
+ * 3 months). Returns null for non-git repos or shallow clones with
+ * insufficient history.
+ */
+
+import { simpleGit } from "simple-git";
+import { median } from "../utils/math.js";
+import type { GitMetrics } from "../types/report.js";
+
+export type { GitMetrics } from "../types/report.js";
+
+const LARGE_COMMIT_THRESHOLD = 500;
+const WEEKS_WINDOW = 13; // ~3 months
+
+/**
+ * Extract commit-level metrics from a repository's Git history.
+ *
+ * @param repoPath - Absolute path to the repository root.
+ * @returns Git metrics, or null if the repo has no history or is not a git repo.
+ */
+export async function extractGitMetrics(
+  repoPath: string,
+): Promise<GitMetrics | null> {
+  try {
+    const git = simpleGit(repoPath);
+
+    const isRepo = await git.checkIsRepo();
+    if (!isRepo) return null;
+
+    const log = await git.log(["--numstat", "--all"]);
+    if (!log.all.length) return null;
+
+    const commitSizes: number[] = [];
+
+    for (const commit of log.all) {
+      const diff = (commit as unknown as { diff?: { files?: Array<{ insertions: number; deletions: number }> } }).diff;
+      if (!diff?.files) continue;
+
+      let linesChanged = 0;
+      for (const file of diff.files) {
+        linesChanged += (file.insertions || 0) + (file.deletions || 0);
+      }
+      commitSizes.push(linesChanged);
+    }
+
+    const totalCommits = log.all.length;
+
+    if (commitSizes.length === 0) {
+      return {
+        totalCommits,
+        medianCommitSize: 0,
+        avgLinesPerCommit: 0,
+        largeCommitRatio: 0,
+        commitsPerWeek: 0,
+      };
+    }
+
+    const sorted = [...commitSizes].sort((a, b) => a - b);
+    const totalLines = commitSizes.reduce((a, b) => a + b, 0);
+    const largeCount = commitSizes.filter(
+      (s) => s > LARGE_COMMIT_THRESHOLD,
+    ).length;
+
+    const now = Date.now();
+    const windowStart = now - WEEKS_WINDOW * 7 * 24 * 60 * 60 * 1000;
+    const recentCommits = log.all.filter((c) => {
+      const d = new Date(c.date).getTime();
+      return d >= windowStart;
+    }).length;
+
+    return {
+      totalCommits,
+      medianCommitSize: median(sorted),
+      avgLinesPerCommit:
+        Math.round((totalLines / commitSizes.length) * 10) / 10,
+      largeCommitRatio:
+        Math.round((largeCount / commitSizes.length) * 1000) / 10,
+      commitsPerWeek:
+        Math.round((recentCommits / WEEKS_WINDOW) * 10) / 10,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/pipeline/analyzeRepo.ts
+++ b/src/pipeline/analyzeRepo.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import { discoverSourceFiles } from "../collect/fileDiscovery.js";
 import { profileRepo } from "../collect/loc.js";
 import { detectDuplication } from "../collect/duplication.js";
+import { extractGitMetrics } from "../collect/gitMetrics.js";
 import { parseTypeScript } from "../parsing/tsParser.js";
 import { countFunctions } from "../extract/functionCount.js";
 import { extractFunctionMetrics } from "../extract/functionMetrics.js";
@@ -100,6 +101,7 @@ export async function analyzeRepo(repoPath: string) {
 
   const complexitySummary = summarizeComplexity(allComplexities);
   const duplication = await detectDuplication(repoPath);
+  const git = await extractGitMetrics(repoPath);
 
   return {
     repoPath,
@@ -112,6 +114,7 @@ export async function analyzeRepo(repoPath: string) {
     complexity: complexitySummary,
     smells: totalSmells,
     duplication,
+    git,
     perFile,
   };
 }

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -62,6 +62,15 @@ export interface ComplexitySummary {
   highComplexityFunctions: number;
 }
 
+/** Git history metrics derived from commit log analysis. */
+export interface GitMetrics {
+  totalCommits: number;
+  medianCommitSize: number;
+  avgLinesPerCommit: number;
+  largeCommitRatio: number;
+  commitsPerWeek: number;
+}
+
 /** Code duplication metrics from jscpd analysis. */
 export interface DuplicationMetrics {
   percentage: number;


### PR DESCRIPTION
## Summary
Closes #6

- `src/collect/gitMetrics.ts` using simple-git to parse commit log with `--numstat`
- Metrics: totalCommits, medianCommitSize, avgLinesPerCommit, largeCommitRatio, commitsPerWeek
- Null fallback for non-git repos or failures
- Type in shared `src/types/report.ts`

## Test plan
- [x] Self-analysis: 13 commits, median 235, avg 457.9, 25% large, 1/week

Made with [Cursor](https://cursor.com)