### PR TITLE
Add Framework Detection Module

### DIFF
--- a/src/collect/frameworkDetection.ts
+++ b/src/collect/frameworkDetection.ts
@@ -1,0 +1,67 @@
+/**
+ * Framework detection module.
+ *
+ * Inspects a repository's package.json to determine the primary framework
+ * and runtime. Recognized frameworks: Next.js, React, NestJS, Fastify,
+ * Express, and plain Node. Falls back to "Node" if no known framework
+ * dependency is found, or returns null if package.json is missing.
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { FrameworkInfo } from "../types/report.js";
+
+export type { FrameworkInfo } from "../types/report.js";
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+/**
+ * Detect the primary framework and runtime of a repository.
+ *
+ * Reads the target repo's package.json and checks dependencies +
+ * devDependencies for known frameworks. Priority order:
+ * Next.js > NestJS > Fastify > Express > React > Node.
+ *
+ * @param repoPath - Absolute path to the repository root.
+ * @returns Framework classification, or null if no package.json exists.
+ */
+export async function detectFramework(
+  repoPath: string,
+): Promise<FrameworkInfo | null> {
+  try {
+    const raw = await readFile(
+      path.join(repoPath, "package.json"),
+      "utf8",
+    );
+    const pkg = JSON.parse(raw) as PackageJson;
+
+    const allDeps = {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    };
+
+    const has = (name: string) => name in allDeps;
+
+    const hasReact = has("react");
+    const hasNext = has("next");
+    const hasExpress = has("express");
+    const hasNest = has("@nestjs/core");
+    const hasFastify = has("fastify");
+
+    const hasBackend = hasExpress || hasNest || hasFastify || hasNext;
+
+    let type = "Node";
+    if (hasNext) type = "Next.js";
+    else if (hasNest) type = "NestJS";
+    else if (hasFastify) type = "Fastify";
+    else if (hasExpress) type = "Express";
+    else if (hasReact) type = "React";
+
+    return { type, hasReact, hasBackend };
+  } catch {
+    return null;
+  }
+}

--- a/src/pipeline/analyzeRepo.ts
+++ b/src/pipeline/analyzeRepo.ts
@@ -13,6 +13,7 @@ import { discoverSourceFiles } from "../collect/fileDiscovery.js";
 import { profileRepo } from "../collect/loc.js";
 import { detectDuplication } from "../collect/duplication.js";
 import { extractGitMetrics } from "../collect/gitMetrics.js";
+import { detectFramework } from "../collect/frameworkDetection.js";
 import { parseTypeScript } from "../parsing/tsParser.js";
 import { countFunctions } from "../extract/functionCount.js";
 import { extractFunctionMetrics } from "../extract/functionMetrics.js";
@@ -102,6 +103,7 @@ export async function analyzeRepo(repoPath: string) {
   const complexitySummary = summarizeComplexity(allComplexities);
   const duplication = await detectDuplication(repoPath);
   const git = await extractGitMetrics(repoPath);
+  const framework = await detectFramework(repoPath);
 
   return {
     repoPath,
@@ -115,6 +117,7 @@ export async function analyzeRepo(repoPath: string) {
     smells: totalSmells,
     duplication,
     git,
+    framework,
     perFile,
   };
 }

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -62,6 +62,13 @@ export interface ComplexitySummary {
   highComplexityFunctions: number;
 }
 
+/** Detected framework and runtime classification. */
+export interface FrameworkInfo {
+  type: string;
+  hasReact: boolean;
+  hasBackend: boolean;
+}
+
 /** Git history metrics derived from commit log analysis. */
 export interface GitMetrics {
   totalCommits: number;


### PR DESCRIPTION
## Summary
Closes #7

- `src/collect/frameworkDetection.ts` reads package.json to classify framework
- Priority: Next.js > NestJS > Fastify > Express > React > Node
- Returns `{ type, hasReact, hasBackend }` or null
- Type in shared `src/types/report.ts`

## Test plan
- [x] Self-analysis: correctly identified as Node (no React, no backend)

Made with [Cursor](https://cursor.com)