### PR TITLE
Add Batch Mode for Analyzing Multiple Repositories

### DIFF
--- a/src/batch/batchAnalyze.ts
+++ b/src/batch/batchAnalyze.ts
@@ -1,0 +1,130 @@
+/**
+ * Batch analysis module.
+ *
+ * Scans a parent directory for sub-directories that contain a package.json,
+ * runs analyzeRepo() on each, writes individual JSON reports to an output
+ * directory, and optionally produces a CSV summary with one row per repo.
+ */
+
+import { readdir, stat, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { analyzeRepo } from "../pipeline/analyzeRepo.js";
+import type { RepoReport } from "../types/report.js";
+
+/**
+ * Check whether a directory looks like a valid repo (has package.json).
+ */
+async function isRepo(dirPath: string): Promise<boolean> {
+  try {
+    const s = await stat(path.join(dirPath, "package.json"));
+    return s.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Generate a CSV summary from an array of reports.
+ *
+ * @param reports - Array of [repoName, report] tuples.
+ * @returns CSV string with headers and one row per repo.
+ */
+function buildCsv(reports: Array<[string, RepoReport]>): string {
+  const headers = [
+    "repo",
+    "files",
+    "totalLOC",
+    "sourceLOC",
+    "testLOC",
+    "functions",
+    "avgFunctionLength",
+    "medianFunctionLength",
+    "maxNesting",
+    "avgComplexity",
+    "maxComplexity",
+    "longFunctions",
+    "deepNesting",
+    "emptyCatches",
+    "consoleLogs",
+    "duplicationPct",
+    "framework",
+    "totalCommits",
+  ];
+
+  const rows = reports.map(([name, r]) => [
+    name,
+    r.filesAnalyzed,
+    r.profile.totalLOC,
+    r.profile.sourceLOC,
+    r.profile.testLOC,
+    r.totals.functions,
+    r.functionMetricsSummary.averageLength,
+    r.functionMetricsSummary.medianLength,
+    r.functionMetricsSummary.maxNestingDepth,
+    r.complexity.average,
+    r.complexity.max,
+    r.smells.longFunctions,
+    r.smells.deepNesting,
+    r.smells.emptyCatchBlocks,
+    r.smells.consoleLogs,
+    r.duplication?.percentage ?? "",
+    r.framework?.type ?? "",
+    r.git?.totalCommits ?? "",
+  ]);
+
+  return [headers.join(","), ...rows.map((r) => r.join(","))].join("\n") + "\n";
+}
+
+export interface BatchOptions {
+  parentDir: string;
+  outputDir: string;
+  csv: boolean;
+}
+
+/**
+ * Analyze every repo sub-directory under parentDir.
+ *
+ * @param opts - Batch configuration (parent dir, output dir, csv flag).
+ * @returns Number of repos successfully analyzed.
+ */
+export async function batchAnalyze(opts: BatchOptions): Promise<number> {
+  const { parentDir, outputDir, csv } = opts;
+
+  await mkdir(outputDir, { recursive: true });
+
+  const entries = await readdir(parentDir, { withFileTypes: true });
+  const dirs = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => path.join(parentDir, e.name));
+
+  const reports: Array<[string, RepoReport]> = [];
+
+  for (const dir of dirs) {
+    const name = path.basename(dir);
+
+    if (!(await isRepo(dir))) {
+      console.error(`Skipping ${name}: no package.json`);
+      continue;
+    }
+
+    try {
+      console.error(`Analyzing ${name}...`);
+      const report = await analyzeRepo(dir);
+      reports.push([name, report]);
+
+      const outPath = path.join(outputDir, `${name}.json`);
+      await writeFile(outPath, JSON.stringify(report, null, 2));
+      console.error(`  -> ${outPath}`);
+    } catch (err) {
+      console.error(`  Error analyzing ${name}:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  if (csv && reports.length > 0) {
+    const csvPath = path.join(outputDir, "summary.csv");
+    await writeFile(csvPath, buildCsv(reports));
+    console.error(`CSV summary -> ${csvPath}`);
+  }
+
+  return reports.length;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,19 +1,52 @@
 /**
  * CLI entrypoint for repo-metrics.
  *
- * Accepts a single argument — the absolute path to a TypeScript repo — runs
- * the full analysis pipeline, and prints a JSON report to stdout containing
- * file counts, total function counts, and per-file function counts.
+ * Supports two modes:
+ *   Single:  npm run dev -- /path/to/repo
+ *   Batch:   npm run dev -- batch /path/to/repos-folder [--output dir] [--csv]
  *
- * Usage: npm run dev -- /path/to/target/repo
+ * Single mode prints a JSON report to stdout.
+ * Batch mode writes individual JSON files per repo and optionally a CSV summary.
  */
 
+import path from "node:path";
 import { analyzeRepo } from "./pipeline/analyzeRepo.js";
+import { batchAnalyze } from "./batch/batchAnalyze.js";
 
 async function main() {
-  const repoPath = process.argv[2];
+  const args = process.argv.slice(2);
+
+  if (args[0] === "batch") {
+    const parentDir = args[1];
+    if (!parentDir) {
+      console.error("Usage: npm run dev -- batch /path/to/repos [--output dir] [--csv]");
+      process.exit(1);
+    }
+
+    let outputDir = path.join(parentDir, "reports");
+    let csv = false;
+
+    for (let i = 2; i < args.length; i++) {
+      if (args[i] === "--output" && args[i + 1]) {
+        outputDir = args[++i]!;
+      } else if (args[i] === "--csv") {
+        csv = true;
+      }
+    }
+
+    const count = await batchAnalyze({
+      parentDir: path.resolve(parentDir),
+      outputDir: path.resolve(outputDir),
+      csv,
+    });
+    console.error(`Done. Analyzed ${count} repositories.`);
+    return;
+  }
+
+  const repoPath = args[0];
   if (!repoPath) {
     console.error("Usage: npm run dev -- /path/to/target/repo");
+    console.error("       npm run dev -- batch /path/to/repos [--output dir] [--csv]");
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
Closes #9

- `src/batch/batchAnalyze.ts` scans a parent directory for repo sub-folders
- CLI `batch` subcommand with `--output` and `--csv` flags
- Individual JSON reports per repo, optional CSV summary row
- Graceful error handling: failing repos are skipped with warning
- CSV columns: repo, files, LOC, functions, complexity, smells, duplication, framework, commits

## Test plan
- [x] Single-repo mode still works unchanged
- [x] Batch module compiles and exports correctly

Made with [Cursor](https://cursor.com)