### PR TITLE
Add Test Coverage Proxy Metric

### DIFF
--- a/src/extract/testCoverageProxy.ts
+++ b/src/extract/testCoverageProxy.ts
@@ -1,0 +1,40 @@
+/**
+ * Test coverage proxy metric.
+ *
+ * Computes the ratio of test LOC to source LOC as a static proxy for
+ * actual test coverage. Classified as:
+ *   - low:      ratio < 0.1
+ *   - moderate: 0.1 <= ratio <= 0.3
+ *   - high:     ratio > 0.3
+ *
+ * This avoids the need to run tests with instrumentation while still
+ * providing a useful signal of testing investment.
+ */
+
+import type { RepoProfile, TestCoverageProxy } from "../types/report.js";
+
+export type { TestCoverageProxy } from "../types/report.js";
+
+/**
+ * Compute the test coverage proxy from LOC data.
+ *
+ * @param profile - Repository profile with sourceLOC and testLOC.
+ * @returns Ratio and classification.
+ */
+export function computeTestCoverageProxy(
+  profile: RepoProfile,
+): TestCoverageProxy {
+  if (profile.sourceLOC === 0) {
+    return { ratio: 0, classification: "low" };
+  }
+
+  const ratio =
+    Math.round((profile.testLOC / profile.sourceLOC) * 100) / 100;
+
+  let classification: TestCoverageProxy["classification"];
+  if (ratio < 0.1) classification = "low";
+  else if (ratio <= 0.3) classification = "moderate";
+  else classification = "high";
+
+  return { ratio, classification };
+}

--- a/src/pipeline/analyzeRepo.ts
+++ b/src/pipeline/analyzeRepo.ts
@@ -19,6 +19,7 @@ import { countFunctions } from "../extract/functionCount.js";
 import { extractFunctionMetrics } from "../extract/functionMetrics.js";
 import { computeComplexity, summarizeComplexity } from "../extract/complexity.js";
 import { detectSmells } from "../extract/smells.js";
+import { computeTestCoverageProxy } from "../extract/testCoverageProxy.js";
 import { LONG_FUNCTION_THRESHOLD } from "../utils/constants.js";
 import { median } from "../utils/math.js";
 import type {
@@ -96,6 +97,7 @@ export async function analyzeRepo(repoPath: string): Promise<RepoReport> {
   };
 
   const complexitySummary = summarizeComplexity(allComplexities);
+  const testCoverageProxy = computeTestCoverageProxy(profile);
   const duplication = await detectDuplication(repoPath);
   const git = await extractGitMetrics(repoPath);
   const framework = await detectFramework(repoPath);
@@ -110,6 +112,7 @@ export async function analyzeRepo(repoPath: string): Promise<RepoReport> {
     functionMetricsSummary,
     complexity: complexitySummary,
     smells: totalSmells,
+    testCoverageProxy,
     duplication,
     git,
     framework,

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -94,6 +94,12 @@ export interface SmellCounts {
   consoleLogs: number;
 }
 
+/** Test coverage proxy derived from LOC ratios. */
+export interface TestCoverageProxy {
+  ratio: number;
+  classification: "low" | "moderate" | "high";
+}
+
 /** Per-file metrics entry in the report. */
 export interface PerFileEntry {
   file: string;
@@ -117,6 +123,7 @@ export interface RepoReport {
   functionMetricsSummary: FunctionMetricsSummary;
   complexity: ComplexitySummary;
   smells: SmellCounts;
+  testCoverageProxy: TestCoverageProxy;
   duplication: DuplicationMetrics | null;
   git: GitMetrics | null;
   framework: FrameworkInfo | null;


### PR DESCRIPTION
## Summary
Closes #10

- `src/extract/testCoverageProxy.ts` computes testLOC/sourceLOC ratio
- Classification: low < 0.1, moderate 0.1-0.3, high > 0.3
- Added `TestCoverageProxy` type and `testCoverageProxy` field to `RepoReport`

## Test plan
- [x] Self-analysis: ratio 0, classification "low" (no test files in this repo)

Made with [Cursor](https://cursor.com)