### PR TITLE
Add Maintainability Index

### DIFF
--- a/src/extract/maintainabilityIndex.ts
+++ b/src/extract/maintainabilityIndex.ts
@@ -1,0 +1,50 @@
+/**
+ * Maintainability Index (MI) calculator.
+ *
+ * Uses a simplified version of the Visual Studio / SEI formula:
+ *
+ *   MI = max(0, 171 - 5.2·ln(avgComplexity) - 0.23·ln(totalLOC) - 16.2·ln(avgFunctionLength)) × 100 / 171
+ *
+ * Normalized to a 0–100 scale. Classified as:
+ *   - low:      score < 40
+ *   - moderate: 40 <= score <= 65
+ *   - high:     score > 65
+ *
+ * Reference: Coleman, D. et al. "Using Metrics to Evaluate Software System
+ * Maintainability," IEEE Computer, 1994.
+ */
+
+import type { MaintainabilityResult } from "../types/report.js";
+
+export type { MaintainabilityResult } from "../types/report.js";
+
+/**
+ * Compute the Maintainability Index from pre-computed metrics.
+ *
+ * @param avgComplexity - Average cyclomatic complexity across all functions.
+ * @param totalLOC - Total lines of code in the repository.
+ * @param avgFunctionLength - Average function length in lines.
+ * @returns Normalized MI score (0–100) and classification.
+ */
+export function computeMaintainabilityIndex(
+  avgComplexity: number,
+  totalLOC: number,
+  avgFunctionLength: number,
+): MaintainabilityResult {
+  const safeLog = (v: number) => Math.log(Math.max(v, 1));
+
+  const raw =
+    171 -
+    5.2 * safeLog(avgComplexity) -
+    0.23 * safeLog(totalLOC) -
+    16.2 * safeLog(avgFunctionLength);
+
+  const score = Math.round(Math.max(0, raw) * 100 / 171 * 10) / 10;
+
+  let classification: MaintainabilityResult["classification"];
+  if (score < 40) classification = "low";
+  else if (score <= 65) classification = "moderate";
+  else classification = "high";
+
+  return { score, classification };
+}

--- a/src/pipeline/analyzeRepo.ts
+++ b/src/pipeline/analyzeRepo.ts
@@ -20,6 +20,7 @@ import { extractFunctionMetrics } from "../extract/functionMetrics.js";
 import { computeComplexity, summarizeComplexity } from "../extract/complexity.js";
 import { detectSmells } from "../extract/smells.js";
 import { computeTestCoverageProxy } from "../extract/testCoverageProxy.js";
+import { computeMaintainabilityIndex } from "../extract/maintainabilityIndex.js";
 import { LONG_FUNCTION_THRESHOLD } from "../utils/constants.js";
 import { median } from "../utils/math.js";
 import type {
@@ -97,6 +98,11 @@ export async function analyzeRepo(repoPath: string): Promise<RepoReport> {
   };
 
   const complexitySummary = summarizeComplexity(allComplexities);
+  const maintainability = computeMaintainabilityIndex(
+    complexitySummary.average,
+    profile.totalLOC,
+    functionMetricsSummary.averageLength,
+  );
   const testCoverageProxy = computeTestCoverageProxy(profile);
   const duplication = await detectDuplication(repoPath);
   const git = await extractGitMetrics(repoPath);
@@ -112,6 +118,7 @@ export async function analyzeRepo(repoPath: string): Promise<RepoReport> {
     functionMetricsSummary,
     complexity: complexitySummary,
     smells: totalSmells,
+    maintainability,
     testCoverageProxy,
     duplication,
     git,

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -94,6 +94,12 @@ export interface SmellCounts {
   consoleLogs: number;
 }
 
+/** Maintainability Index score and classification. */
+export interface MaintainabilityResult {
+  score: number;
+  classification: "low" | "moderate" | "high";
+}
+
 /** Test coverage proxy derived from LOC ratios. */
 export interface TestCoverageProxy {
   ratio: number;
@@ -123,6 +129,7 @@ export interface RepoReport {
   functionMetricsSummary: FunctionMetricsSummary;
   complexity: ComplexitySummary;
   smells: SmellCounts;
+  maintainability: MaintainabilityResult;
   testCoverageProxy: TestCoverageProxy;
   duplication: DuplicationMetrics | null;
   git: GitMetrics | null;


### PR DESCRIPTION
## Summary
Closes #11

- `src/extract/maintainabilityIndex.ts` implements the simplified MI formula
- `MI = max(0, 171 - 5.2·ln(avgComplexity) - 0.23·ln(totalLOC) - 16.2·ln(avgFnLength)) × 100/171`
- Classification: low < 40, moderate 40-65, high > 65
- Uses existing metrics from issues #1, #2, #3 — no new parsing needed

## Test plan
- [x] Self-analysis: score 68.9, classification "high"

Made with [Cursor](https://cursor.com)