### PR TITLE
feat(doc-review): simplify classifier, expand rubrics, and add test fixtures

### DIFF
--- a/apps/dashboard/__tests__/docReview/classifyDocs.test.ts
+++ b/apps/dashboard/__tests__/docReview/classifyDocs.test.ts
@@ -1,130 +1,107 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { classifyDocs } from "../../lib/docReview/classifyDocs";
 import type { FileWithText } from "../../lib/docReview/types";
 
-function mockOpenAiSubmit(classifications: unknown[]) {
-  return {
-    chat: {
-      completions: {
-        create: vi.fn().mockResolvedValue({
-          choices: [
-            {
-              message: {
-                tool_calls: [
-                  {
-                    id: "call_1",
-                    type: "function",
-                    function: {
-                      name: "submit_classifications",
-                      arguments: JSON.stringify({ classifications }),
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        }),
-      },
-    },
-  };
+function file(path: string): FileWithText {
+  return { path, text: "", bytes: 0, truncated: false };
 }
 
-describe("classifyDocs (mocked OpenAI)", () => {
-  it("pre-classifies sprint report filenames without calling OpenAI", async () => {
-    const files: FileWithText[] = [
-      {
-        path: "documentation/sprints/sprint1-report.md",
-        text: "# Sprint 1 Report",
-        bytes: 100,
-        truncated: false,
-      },
-      {
-        path: "documentation/sprints/sprint2-report.md",
-        text: "# Sprint 2 Report",
-        bytes: 100,
-        truncated: false,
-      },
-    ];
-    const openai = {
-      chat: {
-        completions: {
-          create: vi.fn(),
-        },
-      },
-    };
-
+describe("classifyDocs (filename matching)", () => {
+  it("classifies sprint plan by filename", async () => {
     const result = await classifyDocs(
-      files,
-      files.map((f) => f.path),
+      [file("documentation/sprint-1-plan.md")],
       [],
-      openai as never,
-    );
-
-    expect(openai.chat.completions.create).not.toHaveBeenCalled();
-    expect(result).toHaveLength(2);
-    expect(result[0]?.docType).toBe("sprint_report");
-    expect(result[0]?.sprintNumber).toBe(1);
-    expect(result[1]?.sprintNumber).toBe(2);
-  });
-
-  it("classifies sprint plan abbreviations", async () => {
-    const files: FileWithText[] = [
-      { path: "docs/spr1.md", text: "# Sprint 1 Plan", bytes: 100, truncated: false },
-      { path: "docs/spr2.md", text: "# Sprint 2 Plan", bytes: 100, truncated: false },
-    ];
-    const openai = mockOpenAiSubmit([
-      { path: "docs/spr1.md", docType: "sprint_plan", sprintNumber: 1 },
-      { path: "docs/spr2.md", docType: "sprint_plan", sprintNumber: 2 },
-    ]);
-
-    const result = await classifyDocs(
-      files,
-      ["docs/spr1.md", "docs/spr2.md"],
       [],
-      openai as never,
+      null as never,
     );
-
-    expect(result).toHaveLength(2);
     expect(result[0]?.docType).toBe("sprint_plan");
     expect(result[0]?.sprintNumber).toBe(1);
-    expect(result[1]?.sprintNumber).toBe(2);
   });
 
-  it("classifies DoD outside docs folder from repo-wide pool", async () => {
-    const files: FileWithText[] = [
-      {
-        path: "DEFINITION_OF_DONE.md",
-        text: "# Definition of Done",
-        bytes: 80,
-        truncated: false,
-      },
-    ];
-    const openai = mockOpenAiSubmit([
-      { path: "DEFINITION_OF_DONE.md", docType: "definition_of_done" },
-    ]);
+  it("classifies sprint report by filename", async () => {
+    const result = await classifyDocs(
+      [file("documentation/sprint-2-report.md")],
+      [],
+      [],
+      null as never,
+    );
+    expect(result[0]?.docType).toBe("sprint_report");
+    expect(result[0]?.sprintNumber).toBe(2);
+  });
 
-    const result = await classifyDocs(files, [], ["DEFINITION_OF_DONE.md"], openai as never);
+  it("classifies release plan", async () => {
+    const result = await classifyDocs(
+      [file("documentation/release-plan.md")],
+      [],
+      [],
+      null as never,
+    );
+    expect(result[0]?.docType).toBe("release_plan");
+  });
+
+  it("classifies test plan", async () => {
+    const result = await classifyDocs(
+      [file("documentation/test-plan.md")],
+      [],
+      [],
+      null as never,
+    );
+    expect(result[0]?.docType).toBe("test_plan");
+  });
+
+  it("classifies definition of done", async () => {
+    const result = await classifyDocs(
+      [file("documentation/definition-of-done.md")],
+      [],
+      [],
+      null as never,
+    );
     expect(result[0]?.docType).toBe("definition_of_done");
   });
 
-  it("falls back to unknown for all files on OpenAI failure", async () => {
-    const files: FileWithText[] = [
-      { path: "docs/meeting-notes.md", text: "notes", bytes: 10, truncated: false },
-    ];
-    const openai = {
-      chat: {
-        completions: {
-          create: vi.fn().mockRejectedValue(new Error("network")),
-        },
-      },
-    };
-
+  it("classifies code standards", async () => {
     const result = await classifyDocs(
-      files,
-      ["docs/meeting-notes.md"],
+      [file("documentation/code-standards.md")],
       [],
-      openai as never,
+      [],
+      null as never,
+    );
+    expect(result[0]?.docType).toBe("code_standards");
+  });
+
+  it("is case-insensitive", async () => {
+    const result = await classifyDocs(
+      [file("documentation/Sprint-3-Plan.md")],
+      [],
+      [],
+      null as never,
+    );
+    expect(result[0]?.docType).toBe("sprint_plan");
+    expect(result[0]?.sprintNumber).toBe(3);
+  });
+
+  it("returns unknown for unrecognised filenames", async () => {
+    const result = await classifyDocs(
+      [file("documentation/meeting-notes.md")],
+      [],
+      [],
+      null as never,
     );
     expect(result[0]?.docType).toBe("unknown");
+  });
+
+  it("classifies multiple files correctly", async () => {
+    const files = [
+      file("documentation/sprint-1-plan.md"),
+      file("documentation/sprint-1-report.md"),
+      file("documentation/release-plan.md"),
+      file("documentation/random-notes.md"),
+    ];
+    const result = await classifyDocs(files, [], [], null as never);
+    expect(result).toHaveLength(4);
+    expect(result[0]?.docType).toBe("sprint_plan");
+    expect(result[1]?.docType).toBe("sprint_report");
+    expect(result[2]?.docType).toBe("release_plan");
+    expect(result[3]?.docType).toBe("unknown");
   });
 });

--- a/apps/dashboard/__tests__/docReview/constants.test.ts
+++ b/apps/dashboard/__tests__/docReview/constants.test.ts
@@ -7,14 +7,14 @@ import {
 } from "../../lib/docReview/constants";
 
 describe("isDocsPoolPath", () => {
-  it("matches standard and extended docs folder prefixes", () => {
-    expect(isDocsPoolPath("docs/readme.md")).toBe(true);
-    expect(isDocsPoolPath("Documents/Plan.md")).toBe(true);
-    expect(isDocsPoolPath("deliverables/sprint1.pdf")).toBe(true);
-    expect(isDocsPoolPath("artifacts/report.md")).toBe(true);
+  it("matches the documentation folder only", () => {
+    expect(isDocsPoolPath("documentation/readme.md")).toBe(true);
+    expect(isDocsPoolPath("Documentation/Plan.md")).toBe(true);
   });
 
-  it("does not match repo-root or src paths", () => {
+  it("does not match other folders or repo-root paths", () => {
+    expect(isDocsPoolPath("docs/readme.md")).toBe(false);
+    expect(isDocsPoolPath("deliverables/sprint1.md")).toBe(false);
     expect(isDocsPoolPath("README.md")).toBe(false);
     expect(isDocsPoolPath("src/utils.md")).toBe(false);
     expect(isDocsPoolPath("DEFINITION_OF_DONE.md")).toBe(false);
@@ -22,9 +22,9 @@ describe("isDocsPoolPath", () => {
 });
 
 describe("isDocExtension", () => {
-  it("accepts md and pdf case-insensitively", () => {
+  it("accepts markdown only, case-insensitively", () => {
     expect(isDocExtension("file.MD")).toBe(true);
-    expect(isDocExtension("file.PDF")).toBe(true);
+    expect(isDocExtension("file.PDF")).toBe(false);
     expect(isDocExtension("file.txt")).toBe(false);
   });
 });

--- a/apps/dashboard/__tests__/docReview/rubrics.test.ts
+++ b/apps/dashboard/__tests__/docReview/rubrics.test.ts
@@ -4,8 +4,8 @@ import { RUBRICS } from "../../lib/docReview/rubrics";
 describe("RUBRICS", () => {
   it("defines frozen keys for each structured doc type", () => {
     expect(RUBRICS.release_plan.keys).toHaveLength(10);
-    expect(RUBRICS.sprint_plan.keys).toHaveLength(12);
-    expect(RUBRICS.sprint_report.keys).toHaveLength(13);
+    expect(RUBRICS.sprint_plan.keys).toHaveLength(17);
+    expect(RUBRICS.sprint_report.keys).toHaveLength(14);
     expect(RUBRICS.test_plan.keys).toHaveLength(9);
   });
 

--- a/apps/dashboard/components/results/rq/DocReviewTab.tsx
+++ b/apps/dashboard/components/results/rq/DocReviewTab.tsx
@@ -58,6 +58,7 @@ function ChecklistBreakdown({ review }: { review: DocumentReview }) {
   );
 }
 
+
 function ClassificationRow({ doc }: { doc: ClassifiedDoc }) {
   return (
     <tr className="border-b border-border/60 last:border-0">
@@ -116,6 +117,13 @@ function ReviewCard({
 
         {!isUnknown && !review ? (
           <p className="text-muted-foreground">No review result stored for this file.</p>
+        ) : null}
+
+        {review?.structured?.userStoryCount != null ? (
+          <p className="text-sm">
+            <span className="font-medium">User stories: </span>
+            {review.structured.userStoryCount}
+          </p>
         ) : null}
 
         {review && !review.error ? <ChecklistBreakdown review={review} /> : null}
@@ -316,41 +324,25 @@ export function DocReviewTab({ resultId, report }: DocReviewTabProps) {
             </Card>
           ) : null}
 
-          {(docReview.discovery.skippedImages?.length ?? 0) > 0 ? (
+          {docReview.classifications.length > 0 ? (
+            <div className="space-y-4">
+              <h3 className="text-sm font-medium">Document reviews</h3>
+              {docReview.classifications.map((c) => (
+                <ReviewCard key={c.path} doc={c} review={docReview.reviews[c.path]} />
+              ))}
+            </div>
+          ) : stats.skippedImages > 0 && stats.discovered === 0 ? (
             <Card>
               <CardHeader>
-                <CardTitle className="text-base">Skipped image files</CardTitle>
-                <CardDescription>
-                  Only markdown and PDF are reviewed. Export release plans and code standards as
-                  .md or .pdf if you want rubric feedback.
-                </CardDescription>
+                <CardTitle className="text-base flex items-center gap-2">
+                  <Minus className="size-4 text-muted-foreground" aria-hidden />
+                  Documentation present as images only
+                </CardTitle>
               </CardHeader>
-              <CardContent>
-                <ul className="space-y-1 font-mono text-xs text-muted-foreground">
-                  {docReview.discovery.skippedImages!.map((path) => (
-                    <li key={path}>{path}</li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          ) : null}
-
-          {docReview.consistency.warnings.length > 0 ? (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Consistency checks</CardTitle>
-                <CardDescription>
-                  Deterministic checks across classified documents and repo metadata.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <ul className="space-y-2 text-sm">
-                  {docReview.consistency.warnings.map((w) => (
-                    <li key={`${w.code}-${w.message}`} className="text-muted-foreground">
-                      <span className="font-medium text-foreground">{w.code}:</span> {w.message}
-                    </li>
-                  ))}
-                </ul>
+              <CardContent className="text-sm text-muted-foreground">
+                This repo has files under documentation folders, but they are images rather than
+                markdown or PDF. Consistency checks may flag missing release plans or code
+                standards until those are available in a reviewable format.
               </CardContent>
             </Card>
           ) : null}
@@ -403,25 +395,41 @@ export function DocReviewTab({ resultId, report }: DocReviewTabProps) {
             </Card>
           )}
 
-          {docReview.classifications.length > 0 ? (
-            <div className="space-y-4">
-              <h3 className="text-sm font-medium">Document reviews</h3>
-              {docReview.classifications.map((c) => (
-                <ReviewCard key={c.path} doc={c} review={docReview.reviews[c.path]} />
-              ))}
-            </div>
-          ) : stats.skippedImages > 0 && stats.discovered === 0 ? (
+          {docReview.consistency.warnings.length > 0 ? (
             <Card>
               <CardHeader>
-                <CardTitle className="text-base flex items-center gap-2">
-                  <Minus className="size-4 text-muted-foreground" aria-hidden />
-                  Documentation present as images only
-                </CardTitle>
+                <CardTitle className="text-base">Consistency checks</CardTitle>
+                <CardDescription>
+                  Deterministic checks across classified documents and repo metadata.
+                </CardDescription>
               </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
-                This repo has files under documentation folders, but they are images rather than
-                markdown or PDF. Consistency checks may flag missing release plans or code
-                standards until those are available in a reviewable format.
+              <CardContent>
+                <ul className="space-y-2 text-sm">
+                  {docReview.consistency.warnings.map((w) => (
+                    <li key={`${w.code}-${w.message}`} className="text-muted-foreground">
+                      <span className="font-medium text-foreground">{w.code}:</span> {w.message}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {(docReview.discovery.skippedImages?.length ?? 0) > 0 ? (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Skipped image files</CardTitle>
+                <CardDescription>
+                  Only markdown and PDF are reviewed. Export release plans and code standards as
+                  .md or .pdf if you want rubric feedback.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-1 font-mono text-xs text-muted-foreground">
+                  {docReview.discovery.skippedImages!.map((path) => (
+                    <li key={path}>{path}</li>
+                  ))}
+                </ul>
               </CardContent>
             </Card>
           ) : null}

--- a/apps/dashboard/lib/docReview/classifyDocs.ts
+++ b/apps/dashboard/lib/docReview/classifyDocs.ts
@@ -1,350 +1,51 @@
-import type OpenAI from "openai";
-import type { ChatCompletionMessageParam, ChatCompletionTool } from "openai/resources/chat/completions";
-import type { ClassifiedDoc, DocType, FileWithText } from "./types";
-import { inferDocTypeFromFilename } from "./inferDocTypeFromFilename";
-
-const CLASSIFIER_SYSTEM_PROMPT = `You are a document classifier for a university software engineering course.
-Students submit project repositories containing planning and process documents.
-
-Your job is to identify what type each document is, regardless of how it is named.
-Students frequently abbreviate, misspell, or use non-standard filenames.
-
-The possible document types are:
-  release_plan       — The overall release plan for the project (one per project)
-  sprint_plan        — Sprint planning document, one per sprint (numbered 1–4)
-  sprint_report      — Sprint retrospective/report, one per sprint (numbered 1–4)
-  test_plan          — System test plan and report
-  definition_of_done — Definition of done criteria (may cover user stories and/or tasks)
-  code_standards     — Coding style guide or standards (may be language-specific)
-  unknown            — Cannot be classified with confidence
-
-Common abbreviations and misspellings you will encounter:
-  spr1.md, s2plan.md, sp3rep.md   → sprint plans/reports
-  sprint1-report.md, sprint2-report.md → sprint reports
-  repot.md, sprnt2.md             → misspellings of report/sprint
-  dod.md, def-done.md             → definition of done
-  codestds.md, ts-stds.md         → code standards
-  rel-plan.md, releasepl.md       → release plan
-
-Strategy:
-1. Look at ALL filenames together before classifying any — patterns like
-   spr1/spr2/spr3 are strong signals even if each name alone is ambiguous.
-2. Files in the documentation folder are primary candidates for all types.
-3. Files outside the documentation folder are candidates for definition_of_done
-   and code_standards only — do not classify them as sprint or release documents
-   unless their content clearly indicates otherwise.
-4. Use read_file_preview for any file you cannot classify confidently from its name.
-5. Call submit_classifications once with all results when done.
-
-For sprint_plan and sprint_report: always provide sprintNumber (1, 2, 3, or 4).
-Extract sprint number from: filename digits, content heading "Sprint N", or parent
-folder name. If you cannot determine the sprint number, use null.
-
-For code_standards: provide the programming language if identifiable
-(e.g. "TypeScript", "Python", "Java"). Use null for a general standards doc.
-
-When in doubt between two types, call read_file_preview. Only use "unknown" if
-you have read the file preview and still cannot classify it.`;
-
-export const CLASSIFIER_TOOLS: ChatCompletionTool[] = [
-  {
-    type: "function",
-    function: {
-      name: "read_file_preview",
-      description:
-        "Read the first 500 characters of a file's text content. " +
-        "Call this for any file you cannot confidently classify from its filename alone.",
-      parameters: {
-        type: "object",
-        properties: {
-          path: {
-            type: "string",
-            description: "Exact file path as listed in the file list",
-          },
-        },
-        required: ["path"],
-      },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "submit_classifications",
-      description:
-        "Submit your final classification for every file. " +
-        "Call this exactly once when you have classified all files.",
-      parameters: {
-        type: "object",
-        properties: {
-          classifications: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                path: { type: "string" },
-                docType: {
-                  type: "string",
-                  enum: [
-                    "release_plan",
-                    "sprint_plan",
-                    "sprint_report",
-                    "test_plan",
-                    "definition_of_done",
-                    "code_standards",
-                    "unknown",
-                  ],
-                },
-                sprintNumber: {
-                  type: "number",
-                  description: "Sprint number 1–4. Only for sprint_plan and sprint_report.",
-                },
-                language: {
-                  type: "string",
-                  description: "Programming language. Only for code_standards.",
-                },
-              },
-              required: ["path", "docType"],
-            },
-          },
-        },
-        required: ["classifications"],
-      },
-    },
-  },
-];
-
-const MAX_ITERATIONS = 10;
-const CLASSIFIER_TIMEOUT_MS = 30_000;
-
-function buildFileListMessage(docsPool: string[], repoWide: string[]): string {
-  return [
-    "=== DOCUMENTATION FOLDER FILES ===",
-    docsPool.length ? docsPool.join("\n") : "(none)",
-    "",
-    "=== REPO-WIDE FILES (DoD / code standards candidates) ===",
-    repoWide.length ? repoWide.join("\n") : "(none)",
-    "",
-    "Classify every file listed above.",
-  ].join("\n");
-}
-
-function previewText(file: FileWithText | undefined): string {
-  const source = file?.fullText ?? file?.text;
-  if (!source) return "[File not found or text could not be extracted]";
-  return source.slice(0, 500);
-}
-
-function mergeClassification(
-  item: {
-    path: string;
-    docType: string;
-    sprintNumber?: number | null;
-    language?: string | null;
-  },
-  fileByPath: Map<string, FileWithText>,
-): ClassifiedDoc {
-  const file = fileByPath.get(item.path);
-  const docType = item.docType as DocType;
-  return {
-    path: item.path,
-    docType,
-    sprintNumber: item.sprintNumber ?? null,
-    language: item.language ?? null,
-    text: file?.text ?? null,
-    truncated: file?.truncated ?? false,
-  };
-}
-
-function applyFilenameInference(doc: ClassifiedDoc): ClassifiedDoc {
-  if (doc.docType !== "unknown") return doc;
-  const inferred = inferDocTypeFromFilename(doc.path);
-  if (!inferred) return doc;
-  return {
-    ...doc,
-    docType: inferred.docType,
-    sprintNumber: inferred.sprintNumber ?? doc.sprintNumber ?? null,
-    language: inferred.language ?? doc.language ?? null,
-  };
-}
-
-function classifyFromFilename(
-  path: string,
-  fileByPath: Map<string, FileWithText>,
-): ClassifiedDoc | null {
-  const inferred = inferDocTypeFromFilename(path);
-  if (!inferred) return null;
-  const file = fileByPath.get(path);
-  return {
-    path,
-    docType: inferred.docType,
-    sprintNumber: inferred.sprintNumber ?? null,
-    language: inferred.language ?? null,
-    text: file?.text ?? null,
-    truncated: file?.truncated ?? false,
-  };
-}
-
-function fallbackUnknown(files: FileWithText[]): ClassifiedDoc[] {
-  return files.map((f) =>
-    applyFilenameInference({
-      path: f.path,
-      docType: "unknown" as const,
-      text: f.text,
-      truncated: f.truncated,
-    }),
-  );
-}
-
-function mergePreclassifiedAndLlm(
-  allPaths: Set<string>,
-  preClassified: Map<string, ClassifiedDoc>,
-  llmDocs: ClassifiedDoc[],
-): ClassifiedDoc[] {
-  return [...allPaths]
-    .sort()
-    .map((path) => preClassified.get(path) ?? llmDocs.find((d) => d.path === path)!);
-}
+import type { ClassifiedDoc, FileWithText } from "./types";
 
 export async function classifyDocs(
   files: FileWithText[],
-  docsPool: string[],
-  repoWide: string[],
-  openai: OpenAI,
-  signal?: AbortSignal,
+  _docsPool: string[],
+  _repoWide: string[],
+  _openai: unknown,
 ): Promise<ClassifiedDoc[]> {
-  const fileByPath = new Map(files.map((f) => [f.path, f]));
-  const allPaths = new Set([...docsPool, ...repoWide]);
+  return files.map((file): ClassifiedDoc => {
+    const segments = file.path.replace(/\\/g, "/").split("/");
+    const filename = (segments[segments.length - 1] ?? "").toLowerCase();
 
-  if (allPaths.size === 0) return [];
-
-  const preClassified = new Map<string, ClassifiedDoc>();
-  const llmPaths: string[] = [];
-
-  for (const path of [...allPaths].sort()) {
-    const fromFilename = classifyFromFilename(path, fileByPath);
-    if (fromFilename) {
-      preClassified.set(path, fromFilename);
-    } else {
-      llmPaths.push(path);
+    // sprint-{n}-plan.md
+    const sprintPlanMatch = /^sprint-([1-9])-plan\.md$/.exec(filename);
+    if (sprintPlanMatch) {
+      return {
+        path: file.path,
+        docType: "sprint_plan",
+        sprintNumber: Number(sprintPlanMatch[1]),
+      };
     }
-  }
 
-  if (llmPaths.length === 0) {
-    return [...allPaths].sort().map((path) => preClassified.get(path)!);
-  }
-
-  const llmDocsPool = docsPool.filter((p) => llmPaths.includes(p));
-  const llmRepoWide = repoWide.filter((p) => llmPaths.includes(p));
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), CLASSIFIER_TIMEOUT_MS);
-  const combinedSignal = signal
-    ? AbortSignal.any([signal, controller.signal])
-    : controller.signal;
-
-  const messages: ChatCompletionMessageParam[] = [
-    { role: "system", content: CLASSIFIER_SYSTEM_PROMPT },
-    { role: "user", content: buildFileListMessage(llmDocsPool, llmRepoWide) },
-  ];
-
-  try {
-    for (let i = 0; i < MAX_ITERATIONS; i++) {
-      const completion = await openai.chat.completions.create(
-        {
-          model: "gpt-4o-mini",
-          temperature: 0,
-          max_tokens: 2048,
-          messages,
-          tools: CLASSIFIER_TOOLS,
-          tool_choice: "auto",
-        },
-        { signal: combinedSignal },
-      );
-
-      const choice = completion.choices[0];
-      if (!choice?.message) break;
-
-      messages.push(choice.message);
-
-      const toolCalls = choice.message.tool_calls;
-      if (!toolCalls?.length) break;
-
-      for (const call of toolCalls) {
-        if (call.type !== "function") continue;
-        const fn = call.function;
-        let args: Record<string, unknown> = {};
-        try {
-          args = JSON.parse(fn.arguments) as Record<string, unknown>;
-        } catch {
-          args = {};
-        }
-
-        if (fn.name === "read_file_preview") {
-          const path = String(args.path ?? "");
-          messages.push({
-            role: "tool",
-            tool_call_id: call.id,
-            content: previewText(fileByPath.get(path)),
-          });
-          continue;
-        }
-
-        if (fn.name === "submit_classifications") {
-          const list = args.classifications as Array<{
-            path: string;
-            docType: string;
-            sprintNumber?: number | null;
-            language?: string | null;
-          }>;
-          if (!Array.isArray(list)) {
-            messages.push({
-              role: "tool",
-              tool_call_id: call.id,
-              content: "Invalid classifications payload.",
-            });
-            continue;
-          }
-
-          const byPath = new Map(list.map((c) => [c.path, c]));
-          const llmResult: ClassifiedDoc[] = [];
-          for (const path of llmPaths.sort()) {
-            const item = byPath.get(path);
-            if (item) {
-              llmResult.push(applyFilenameInference(mergeClassification(item, fileByPath)));
-            } else {
-              llmResult.push(
-                applyFilenameInference({
-                  path,
-                  docType: "unknown",
-                  text: fileByPath.get(path)?.text ?? null,
-                  truncated: fileByPath.get(path)?.truncated,
-                }),
-              );
-            }
-          }
-          return mergePreclassifiedAndLlm(allPaths, preClassified, llmResult);
-        }
-
-        messages.push({
-          role: "tool",
-          tool_call_id: call.id,
-          content: "Unknown tool.",
-        });
-      }
+    // sprint-{n}-report.md
+    const sprintReportMatch = /^sprint-([1-9])-report\.md$/.exec(filename);
+    if (sprintReportMatch) {
+      return {
+        path: file.path,
+        docType: "sprint_report",
+        sprintNumber: Number(sprintReportMatch[1]),
+      };
     }
-  } catch {
-    return mergePreclassifiedAndLlm(
-      allPaths,
-      preClassified,
-      fallbackUnknown(files.filter((f) => llmPaths.includes(f.path))),
-    );
-  } finally {
-    clearTimeout(timeout);
-  }
 
-  return mergePreclassifiedAndLlm(
-    allPaths,
-    preClassified,
-    fallbackUnknown(files.filter((f) => llmPaths.includes(f.path))),
-  );
+    if (filename === "release-plan.md") {
+      return { path: file.path, docType: "release_plan" };
+    }
+
+    if (filename === "test-plan.md") {
+      return { path: file.path, docType: "test_plan" };
+    }
+
+    if (filename === "definition-of-done.md") {
+      return { path: file.path, docType: "definition_of_done" };
+    }
+
+    if (filename === "code-standards.md") {
+      return { path: file.path, docType: "code_standards" };
+    }
+
+    return { path: file.path, docType: "unknown" };
+  });
 }

--- a/apps/dashboard/lib/docReview/constants.ts
+++ b/apps/dashboard/lib/docReview/constants.ts
@@ -1,14 +1,6 @@
 /** Docs-folder path prefixes (case-insensitive). */
 export const DOCS_POOL_PREFIXES = [
-  "docs/",
-  "doc/",
   "documentation/",
-  "documents/",
-  "project-docs/",
-  "team-docs/",
-  "reports/",
-  "deliverables/",
-  "artifacts/",
 ] as const;
 
 export const MAX_DOC_FILES = 40;
@@ -34,8 +26,7 @@ export function pathDepth(path: string): number {
 }
 
 export function isDocExtension(path: string): boolean {
-  const lower = path.toLowerCase();
-  return lower.endsWith(".md") || lower.endsWith(".pdf");
+  return path.toLowerCase().endsWith(".md");
 }
 
 /** Image types sometimes used for release plans / code standards (not reviewable yet). */

--- a/apps/dashboard/lib/docReview/discoverDocs.ts
+++ b/apps/dashboard/lib/docReview/discoverDocs.ts
@@ -1,12 +1,9 @@
 import type { DiscoveryResult, DiscoveredFile } from "./types";
 import {
-  DOCS_POOL_PREFIXES,
   MAX_DOC_FILES,
   MAX_PATH_DEPTH,
   SKIP_DIR_NAMES,
   isDocExtension,
-  isDocsPoolPath,
-  isSkippedImageExtension,
   pathDepth,
 } from "./constants";
 
@@ -82,16 +79,15 @@ export async function discoverDocs(
     if (pathInSkippedDir(item.path)) continue;
     if (pathDepth(item.path) > MAX_PATH_DEPTH) continue;
 
-    if (isDocsPoolPath(item.path) && isSkippedImageExtension(item.path)) {
-      skippedImages.push(item.path);
-      continue;
-    }
+    // Only look in the documentation/ folder (case-insensitive)
+    const normalizedPath = item.path.replace(/\\/g, "/").toLowerCase();
+    if (!normalizedPath.startsWith("documentation/")) continue;
 
     if (!isDocExtension(item.path)) continue;
 
     candidates.push({
       path: item.path,
-      pool: isDocsPoolPath(item.path) ? "docs" : "repoWide",
+      pool: "docs",
       size: item.size,
     });
   }
@@ -105,29 +101,18 @@ export async function discoverDocs(
     );
   }
 
-  if (skippedImages.length > 0) {
-    const preview = skippedImages.slice(0, 5).join(", ");
-    const extra =
-      skippedImages.length > 5 ? ` (+${skippedImages.length - 5} more)` : "";
-    warnings.push(
-      `Skipped ${skippedImages.length} image file(s) in documentation folders (only .md and .pdf are reviewed): ${preview}${extra}. ` +
-        "If release plans or code standards are PNG/JPG exports, re-export as markdown or PDF.",
-    );
-  }
+  const docsPool = files.map((f) => f.path);
+  const repoWide: string[] = [];
 
-  const docsPool = files.filter((f) => f.pool === "docs").map((f) => f.path);
-  const repoWide = files.filter((f) => f.pool === "repoWide").map((f) => f.path);
-
-  const found =
-    docsPool.length > 0 ||
-    DOCS_POOL_PREFIXES.some((prefix) =>
-      candidates.some((f) =>
-        f.path.toLowerCase().startsWith(prefix.replace(/\/$/, "")),
-      ),
-    );
+  // folder_found: true if any file in the tree starts with documentation/
+  const folder_found = tree.tree.some(
+    (item) =>
+      item.type === "blob" &&
+      item.path.replace(/\\/g, "/").toLowerCase().startsWith("documentation/"),
+  );
 
   return {
-    found: found || files.length > 0,
+    found: folder_found,
     docsPool,
     repoWide,
     files,
@@ -136,4 +121,3 @@ export async function discoverDocs(
   };
 }
 
-export { DOCS_POOL_PREFIXES };

--- a/apps/dashboard/lib/docReview/reviewDoc.ts
+++ b/apps/dashboard/lib/docReview/reviewDoc.ts
@@ -92,6 +92,10 @@ export const REVIEWER_TOOLS: ChatCompletionTool[] = [
           strengths: { type: "string" },
           improvements: { type: "string" },
           coach: { type: "string" },
+          user_story_count: {
+            type: "number",
+            description: "Total number of user stories found in the document. Only populate for sprint_plan documents.",
+          },
         },
       },
     },
@@ -242,9 +246,13 @@ export async function reviewDoc(
             };
           }
           if (normalized.kind === "structured") {
+            const userStoryCount =
+              typeof args.user_story_count === "number"
+                ? args.user_story_count
+                : null;
             return {
               ...base,
-              structured: normalized.payload,
+              structured: { ...normalized.payload, userStoryCount },
               reviewMs: Date.now() - start,
             };
           }

--- a/apps/dashboard/lib/docReview/rubrics.ts
+++ b/apps/dashboard/lib/docReview/rubrics.ts
@@ -48,23 +48,34 @@ Checklist criteria — evaluate each independently:
       "initial_task_assignment",
       "scrum_times_listed",
       "ta_visit_indicated",
+      "capacity_reserved",
+      "acceptance_criteria_present",
+      "user_stories_valuable",
+      "no_epic_stories",
+      "task_descriptions_specific",
     ],
     prompt: `
-Checklist criteria:
-- heading_complete: Heading contains document name ("Sprint N Plan"), product name,
-  team name, sprint completion date, revision number, revision date
-- sprint_goal_present: A sprint goal section exists with 1–2 sentences describing the objective
-- user_stories_present: At least one user story is listed
-- user_stories_format: Stories follow "As a {role}, I want {goal}" format
-- tasks_under_stories: Each user story has at least one task listed beneath it
-- time_estimates_present: Time estimates are provided for individual tasks
-- estimates_within_6h: All individual task time estimates are 6 ideal hours or less
-  (mark false if any single task estimate exceeds 6 hours)
-- story_totals_present: Total hours per user story are summed and listed
-- team_roles_listed: All team members are listed with at least one role each
-- initial_task_assignment: Each team member is assigned an initial user story and task
-- scrum_times_listed: At least 3 scheduled scrum meeting days and times are listed
-- ta_visit_indicated: One of the scrum times is identified as the TA/tutor visit
+Checklist criteria — evaluate each independently. For each key return true (pass) or false (fail).
+
+Also count the total number of user stories in the document and return it as user_story_count.
+
+- heading_complete: Heading contains document name ("Sprint N Plan"), product name, team name, sprint completion date, revision number, revision date. PASS: "Sprint 1 Plan | Team Rocket | Due: May 15 | Rev 1.0 | 2026-04-01". FAIL: Just a title with no metadata.
+- sprint_goal_present: A sprint goal section exists with 1–2 sentences describing the objective. PASS: "Sprint Goal: Deliver user login and profile creation." FAIL: No sprint goal section, or goal is missing.
+- user_stories_present: At least one user story is listed. PASS: Any story in "As a / I want" format. FAIL: No stories at all.
+- user_stories_format: Every story follows "As a {role}, I want {goal} [so that {reason}]" format. PASS: All stories match this template. FAIL: Any story is written as a plain requirement or task description.
+- user_stories_valuable: Every story describes a user-facing action with clear benefit. PASS: "As a player, I want to save my progress so that I can resume later." FAIL: "As a developer, I want to set up the database schema." Technical tasks disguised as stories fail this check.
+- no_epic_stories: No single story is so large it would consume the entire sprint. PASS: Stories are scoped to discrete features completable in days. FAIL: "As a user, I want a fully functional e-commerce system" — obvious epic not broken down.
+- acceptance_criteria_present: Each user story has at least 2 specific, testable acceptance criteria. PASS: Story followed by "AC: 1) Login redirects to dashboard. 2) Invalid credentials show error message." FAIL: No acceptance criteria, or only vague statements like "feature works correctly."
+- tasks_under_stories: Each user story has at least one task listed beneath it. PASS: Story followed by indented task list. FAIL: Stories with no tasks under them.
+- task_descriptions_specific: Tasks use an action verb and name a specific deliverable. PASS: "Code login API endpoint (4h)", "Write unit tests for user model (3h)", "Design database schema (2h)". FAIL: "Backend work", "Do testing", "Help with feature", "Work on sprint."
+- time_estimates_present: Hour estimates are provided for individual tasks. PASS: Each task has "(Xh)" or "X hours" notation. FAIL: Tasks with no time estimates.
+- estimates_within_6h: All individual task time estimates are 6 ideal hours or less. PASS: Largest task is 6h. FAIL: Any single task estimate exceeds 6 hours (e.g. "Implement entire backend (16h)").
+- story_totals_present: Total hours per user story are summed and shown. PASS: "Total: 14h" at the end of a story's task list. FAIL: No story-level totals.
+- capacity_reserved: Team capacity calculation reserves approximately 15% buffer — total committed hours are less than 100% of available hours. PASS: "Team capacity: 80h, committed: 68h (15% buffer)". FAIL: 100% of available hours committed with no buffer mentioned.
+- team_roles_listed: All team members are listed with at least one Scrum role each (PO, SM, Dev). PASS: "Alice – Scrum Master, Bob – Product Owner, Carol – Dev". FAIL: Names listed with no roles, or roles missing entirely.
+- initial_task_assignment: Each team member is assigned an initial user story and task. PASS: Each person has at least one task assigned to them by name. FAIL: Tasks listed with no assignees.
+- scrum_times_listed: At least 3 scheduled scrum meeting days and times are listed. PASS: "Mon/Wed/Fri 10am, Thu 2pm TA visit". FAIL: No meeting schedule, or fewer than 3 times listed.
+- ta_visit_indicated: One of the scrum times is identified as the TA/tutor visit. PASS: One meeting labeled "TA visit" or "tutor check-in". FAIL: No TA visit identified in the schedule.
     `.trim(),
   },
 
@@ -83,6 +94,7 @@ Checklist criteria:
       "velocity_rates_present",
       "cumulative_velocity_present",
       "burnup_chart_present",
+      "burnup_data_present",
     ],
     prompt: `
 Checklist criteria:
@@ -100,7 +112,8 @@ Checklist criteria:
 - velocity_metrics_present: total stories completed, total ideal hours completed, total sprint days
 - velocity_rates_present: Stories/day and hours/day rates are explicitly stated
 - cumulative_velocity_present: For sprint 2+ cumulative averages reported; true for sprint 1
-- burnup_chart_present: A burnup or burndown chart is included or referenced as attachment
+- burnup_chart_present: A burnup or burndown chart image is included or referenced (e.g. ![burnup](burnup.png)). The AI cannot evaluate image quality — presence of a chart reference is sufficient to pass. PASS: Any image reference for a chart. FAIL: No chart image or reference anywhere.
+- burnup_data_present: A day-by-day data table of completed hours per sprint day is present in the document. This is independent of burnup_chart_present — a student may have the chart without the table or vice versa. PASS: Table showing sprint day vs completed hours. FAIL: No data table present. When true, provide coach feedback on: whether the table covers all sprint days, whether data was recorded daily (after each Scrum meeting), whether an ideal trend line or total is referenced, and whether the completion trajectory is plausible.
     `.trim(),
   },
 
@@ -144,17 +157,60 @@ export const HOLISTIC_DOC_TYPES = new Set([
 ]);
 
 export const DOD_CONTEXT = `
-This is a Definition of Done document. It should define criteria for:
-1. When a user story is considered done
-2. When a task is considered done
-Good criteria are specific and testable. Vague criteria like "quality is good" are less useful.
+This is a Definition of Done document. Evaluate it holistically and provide strengths and coach feedback.
+
+A good Definition of Done has TWO required sections:
+
+1. TASK-LEVEL DoD ("Did you build the thing right?" — engineering perspective)
+   Required categories: code checked into repository, code reviewed by a team member, unit tests defined and passing, non-functional tests (usability/performance) considered.
+   GOOD criterion: "Code reviewed by at least one team member before merge into main"
+   BAD criterion: "Code is clean", "Quality is good" (vague, not verifiable)
+
+2. USER STORY-LEVEL DoD ("Did you build the right thing?" — user perspective)
+   Required categories: all tasks for the story are done, acceptance criteria tests passed, inspected and accepted by Product Owner.
+   GOOD criterion: "All acceptance criteria tests pass and are documented"
+   BAD criterion: "Feature works correctly" (not testable)
+
+Evaluate on these dimensions and call out specific issues by name:
+- Coverage: does it have both task-level and story-level sections?
+- Specificity: are criteria specific and verifiable, or vague?
+- Simplicity: 5–10 meaningful items per section is ideal; flag if too sparse (<3) or too long (>12 total)
+- Consistent applicability: criteria should apply to all work items, not be story-specific
+- Missing categories: flag if code review, testing, or repo check-in are absent from task DoD; flag if PO acceptance is absent from story DoD
+
+Return strengths (what is specific and enforceable) and improvements (what is vague, missing, or not consistently applicable).
 `.trim();
 
 export function codeStandardsContext(detectedLanguages: string[]): string {
   return `
-This is a coding standards document.
-The repository uses: ${detectedLanguages.join(", ") || "unknown languages"}.
-Good standards are specific and enforceable (e.g. "use ESLint with airbnb config")
-rather than vague (e.g. "write clean code").
+This is a coding standards document for a repository using: ${detectedLanguages.join(", ") || "unknown languages"}.
+Evaluate it holistically and provide strengths and coach feedback.
+
+A good coding standards document:
+1. References an established style guide rather than inventing rules from scratch.
+   GOOD: "We follow Google Java Style Guide" or "We use ESLint with Airbnb config"
+   BAD: Entirely custom rules with no established standard cited
+
+2. Addresses naming conventions specifically for the languages used.
+   - Variable names: accurate, purposeful, pronounceable, length matches scope
+   - Function names: describe what they do — flag vague verbs like handleCalcs(), processInput(), doStuff()
+   - No magic numbers — named constants required
+   GOOD: "All boolean variables use is/has prefix (isLoggedIn, hasPermission)"
+   BAD: "Use good variable names"
+
+3. Specifies formatting rules.
+   Must address: indentation (spaces vs tabs, how many), whitespace usage, brace/parenthesis placement.
+   GOOD: "Use 2-space indentation, opening brace on same line as declaration"
+   BAD: No formatting rules at all
+
+4. Encourages best practices.
+   Look for: DRY (Don't Repeat Yourself), single responsibility, clarity over cleverness.
+   Slides: "Ease of reading and understanding is more important than ease of writing/clever coding"
+
+5. Is language-appropriate.
+   Standards should reference the actual languages in this repo (${detectedLanguages.join(", ") || "unknown"}).
+   Flag if standards are completely generic and don't mention the actual stack.
+
+Evaluate on all five dimensions. Return strengths (what is specific and enforceable) and improvements (what is vague, generic, missing, or not matched to the repo's languages).
 `.trim();
 }

--- a/apps/dashboard/lib/docReview/runDocReview.ts
+++ b/apps/dashboard/lib/docReview/runDocReview.ts
@@ -91,7 +91,6 @@ export async function runDocReview(opts: {
     discovery.docsPool,
     discovery.repoWide,
     openai,
-    signal,
   );
   classifyMs = Date.now() - classifyStart;
 

--- a/apps/dashboard/lib/docReview/types.ts
+++ b/apps/dashboard/lib/docReview/types.ts
@@ -48,6 +48,7 @@ export interface ClassifiedDoc {
 export interface StructuredReviewPayload {
   checklist: Record<string, boolean>;
   coach: string;
+  userStoryCount?: number | null;
 }
 
 export interface HolisticReviewPayload {

--- a/documentation-case-01-happy-path/code-standards.md
+++ b/documentation-case-01-happy-path/code-standards.md
@@ -1,0 +1,47 @@
+# Code Standards | Campus Event App | Team Rocket | Rev 1.0 | 2026-05-01
+
+## Style Guides
+
+This project follows the [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html) and enforces rules via the [Airbnb ESLint config](https://github.com/airbnb/javascript) (`eslint-config-airbnb-typescript`).
+
+---
+
+## Naming Conventions
+
+- **Boolean variables** must use the `is` or `has` prefix (e.g., `isLoading`, `hasError`, `isAuthenticated`)
+- **Functions** are named with a verb+noun pattern (e.g., `fetchEvents`, `renderLoginForm`, `validateEmail`)
+- **No magic numbers** — extract numeric literals into named constants (e.g., `const MAX_LOGIN_ATTEMPTS = 3`)
+- **Constants** use `UPPER_SNAKE_CASE`; variables and parameters use `camelCase`
+
+---
+
+## Formatting
+
+- **Indentation:** 2 spaces (no tabs)
+- **Opening braces:** same line as the statement (`if (x) {`, not on the next line)
+- **Strings:** single quotes for all string literals; template literals for interpolation
+- **Semicolons:** required at end of all statements
+- **Max line length:** 100 characters
+
+---
+
+## Best Practices
+
+- **DRY (Don't Repeat Yourself):** extract repeated logic into shared utility functions in `/lib/utils/`
+- **Single responsibility:** each function does one thing; if a function needs a comment to explain what it does, it should be split
+- **Clarity over cleverness:** prefer readable code over terse one-liners; code is read more than it is written
+- **No `any` types:** use proper TypeScript types or `unknown` with type guards
+
+---
+
+## React-Specific
+
+- **Components** are named in PascalCase and live in `/components/` (e.g., `EventCard.tsx`, `LoginForm.tsx`)
+- **Custom hooks** are prefixed with `use` (e.g., `useAuth`, `useEventList`)
+- **Props interfaces** are defined above the component and named `<ComponentName>Props`
+
+---
+
+## Stack Reference
+
+This repo uses **TypeScript** (strict mode) and **React 18** for the frontend, with **Node.js/Express** for the API layer. All new code must be fully typed.

--- a/documentation-case-01-happy-path/definition-of-done.md
+++ b/documentation-case-01-happy-path/definition-of-done.md
@@ -1,0 +1,20 @@
+# Definition of Done | Campus Event App | Team Rocket | Rev 1.0 | 2026-05-01
+
+## Task Level — "Did we build it right?"
+
+A task is done when ALL of the following are true:
+
+- Code reviewed by at least one other team member before merging into main
+- All unit tests pass in CI (`npm test` returns 0 failures)
+- Code pushed to `main` branch via pull request (no direct pushes)
+- No ESLint errors (`npm run lint` passes with 0 errors)
+- External APIs and public functions documented with JSDoc comments
+
+## User Story Level — "Did we build the right thing?"
+
+A user story is done when ALL of the following are true:
+
+- All tasks for the story are marked complete and meet the Task-Level DoD
+- All acceptance criteria tests have been executed and results documented in the test plan
+- Feature reviewed and approved by the Product Owner (verbal or written sign-off)
+- Help text or user-facing documentation updated if the feature introduces new UI elements or user interactions

--- a/documentation-case-01-happy-path/release-plan.md
+++ b/documentation-case-01-happy-path/release-plan.md
@@ -1,0 +1,38 @@
+# Release Plan | Campus Event App | Team Rocket | Release: MVP v1.0 | Release Date: June 14, 2026 | Rev 1.0 | 2026-05-01
+
+## High-Level Goals
+
+1. Deliver a working MVP with user registration, login, event browsing, and RSVP by June 14.
+2. Ensure the app is accessible on both desktop and mobile browsers.
+3. Achieve at least 80% unit test coverage across API endpoints before release.
+
+---
+
+## User Stories
+
+| ID   | Story                                                                                                   | Points | Sprint   | Priority |
+|------|---------------------------------------------------------------------------------------------------------|--------|----------|----------|
+| US-1 | As a new visitor, I want to register an account so that I can access the platform                       | 5      | Sprint 1 | High     |
+| US-2 | As a registered user, I want to log in so that I can access my dashboard                                | 5      | Sprint 1 | High     |
+| US-3 | As a logged-in student, I want to browse upcoming events so that I can find ones relevant to me         | 8      | Sprint 1 | High     |
+| US-4 | As a logged-in student, I want to RSVP to events so that I can track events I plan to attend           | 5      | Sprint 1 | High     |
+| US-5 | As an event organizer, I want to create and publish events so that students can discover them           | 8      | Sprint 2 | Medium   |
+| US-6 | As a logged-in user, I want to receive email reminders for RSVP'd events so that I don't miss them     | 5      | Sprint 2 | Low      |
+
+---
+
+## Capacity Check
+
+- Team velocity (baseline): 36 story points per sprint
+- Sprint 1 commitment: 23 points (US-1 + US-2 + US-3 + US-4)
+- Sprint 2 commitment: 13 points (US-5 + US-6)
+- Total release points: 36 — within two-sprint team capacity
+
+---
+
+## Product Backlog (Not In This Release)
+
+| ID   | Story                                                                                                     | Notes                          |
+|------|-----------------------------------------------------------------------------------------------------------|--------------------------------|
+| US-7 | As an admin, I want to moderate reported events so that inappropriate content is removed                  | Deferred to v1.1               |
+| US-8 | As a user, I want to follow other users so that I can see which events my friends are attending           | Deferred — social features post-MVP |

--- a/documentation-case-01-happy-path/sprint-1-plan.md
+++ b/documentation-case-01-happy-path/sprint-1-plan.md
@@ -1,0 +1,101 @@
+# Sprint 1 Plan | Campus Event App | Team Rocket | Due: May 30, 2026 | Rev 1.0 | 2026-05-01
+
+## Team
+- Alice — Scrum Master
+- Bob — Product Owner
+- Carol — Developer
+- Dave — Developer
+
+## Sprint Goal
+Deliver user registration, login, event browsing, and event RSVP for the Campus Event App MVP demo on May 30.
+
+## Capacity
+- Team available hours: 120h
+- Committed hours: 100h
+- Buffer reserved: 20h (17%)
+
+## Scrum Times
+- Monday 10:00am — Daily Standup
+- Wednesday 10:00am — Daily Standup
+- Thursday 2:00pm — TA Visit (weekly)
+- Friday 10:00am — Sprint Review / Retrospective Prep
+
+---
+
+## User Stories
+
+### US-1: User Registration
+**As a** new visitor, **I want to** register an account with my email and password, **so that** I can access the Campus Event App.
+
+**Acceptance Criteria:**
+1. Given I am on the registration page, when I submit a valid email and password (8+ chars), then my account is created and I am redirected to the dashboard.
+2. Given I submit an email already in use, when I click Register, then I see the error "An account with this email already exists."
+
+**Tasks:**
+- [ ] Design registration form component with email/password fields and validation messages (4h) — Carol
+- [ ] Implement POST /api/auth/register endpoint with email uniqueness check and bcrypt hashing (6h) — Dave
+- [ ] Write Jest unit tests for registration validation logic (3h) — Carol
+- [ ] Connect frontend form to API and handle success/error responses (3h) — Carol
+
+**Story Total: 16h**
+
+---
+
+### US-2: User Login
+**As a** registered user, **I want to** log in with my email and password, **so that** I can access my personalized dashboard.
+
+**Acceptance Criteria:**
+1. Given I enter valid credentials, when I click Log In, then I am authenticated and redirected to my dashboard with my name displayed.
+2. Given I enter an incorrect password three times, when I attempt a fourth login, then my account is temporarily locked for 15 minutes and I see a lockout message.
+
+**Tasks:**
+- [ ] Build login form component with field validation and error display (3h) — Carol
+- [ ] Implement POST /api/auth/login with JWT issuance and rate-limiting middleware (6h) — Dave
+- [ ] Add account lockout logic after 3 failed attempts (4h) — Dave
+- [ ] Write unit tests for login endpoint and lockout behavior (4h) — Carol
+
+**Story Total: 17h**
+
+---
+
+### US-3: Browse Upcoming Events
+**As a** logged-in student, **I want to** browse a list of upcoming campus events, **so that** I can find events relevant to my interests.
+
+**Acceptance Criteria:**
+1. Given I am on the events page, when the page loads, then I see a paginated list of events sorted by date with title, date, location, and category.
+2. Given I filter by category "Academic", when results update, then only events tagged "Academic" are shown.
+
+**Tasks:**
+- [ ] Create EventList component with pagination and category filter UI (5h) — Carol
+- [ ] Implement GET /api/events endpoint with query params for category and page (4h) — Dave
+- [ ] Seed database with 20 sample events across 4 categories (2h) — Bob
+- [ ] Write integration test for event list filtering (3h) — Carol
+
+**Story Total: 14h**
+
+---
+
+### US-4: RSVP to an Event
+**As a** logged-in student, **I want to** RSVP to an event, **so that** I can keep track of events I plan to attend.
+
+**Acceptance Criteria:**
+1. Given I am viewing an event detail page, when I click "RSVP", then my RSVP is saved and the button changes to "You're going" with a green indicator.
+2. Given I have already RSVP'd, when I click "Cancel RSVP", then my RSVP is removed and the button returns to its default state.
+
+**Tasks:**
+- [ ] Add RSVP button component with toggling state and optimistic UI update (4h) — Carol
+- [ ] Implement POST /api/events/:id/rsvp and DELETE /api/events/:id/rsvp endpoints (5h) — Dave
+- [ ] Display RSVP count on event detail page (2h) — Carol
+- [ ] Write unit tests for RSVP toggle endpoints (3h) — Dave
+
+**Story Total: 14h**
+
+---
+
+## Initial Task Assignments
+- Carol: US-1 tasks 1, 3, 4 · US-2 task 1 · US-3 tasks 1, 4 · US-4 tasks 1, 3
+- Dave: US-1 task 2 · US-2 tasks 2, 3 · US-3 task 2 · US-4 tasks 2, 4
+- Bob: US-3 task 3 (seed data), Product Backlog grooming
+- Alice: Facilitates standups, removes blockers, coordinates TA visit agenda
+
+**Total committed: 61h (Alice/Bob overhead ~39h = 100h total)**

--- a/documentation-case-01-happy-path/sprint-1-report.md
+++ b/documentation-case-01-happy-path/sprint-1-report.md
@@ -1,0 +1,92 @@
+# Sprint 1 Report | Campus Event App | Team Rocket | Sprint End: May 30, 2026 | Rev 1.0 | 2026-05-30
+
+## Summary
+Sprint 1 concluded successfully. All four planned user stories were completed and demoed to the Product Owner on May 30.
+
+---
+
+## STOP
+
+1. **Skipping PR descriptions** — Several pull requests were merged with empty description fields. This made it hard for reviewers to understand the intent of changes without reading the full diff. We should stop merging PRs without at least a one-sentence summary.
+
+2. **Unplanned ad-hoc design changes mid-sprint** — On Day 6, the login form was redesigned without consulting the PO, which caused a 4-hour rework cycle. We should stop making UI decisions without a quick PO check-in first.
+
+---
+
+## START
+
+1. **Daily async status update in Slack** — Our standups ran over 20 minutes three times this sprint. Starting a brief async Slack thread each morning before the standup would let us cover blockers faster and shorten live meetings.
+
+2. **Definition of Done checklist on every PR** — We had two PRs merged without unit tests because the checklist wasn't consistently applied. Attaching the DoD checklist as a PR template will make this a friction-free habit.
+
+---
+
+## KEEP
+
+1. **Pair programming for new feature endpoints** — Carol and Dave pairing on the RSVP endpoints reduced bugs and knowledge silos. This worked well and should continue for complex backend tasks.
+
+2. **Thursday TA visit with prepared questions** — Having a written agenda for the TA visit each week made the sessions focused and actionable. We should keep preparing 3–5 questions before each visit.
+
+---
+
+## Completed Stories
+
+| Story ID | Title                  | Hours Logged |
+|----------|------------------------|-------------|
+| US-1     | User Registration       | 16h         |
+| US-2     | User Login              | 17h         |
+| US-3     | Browse Upcoming Events  | 14h         |
+| US-4     | RSVP to an Event        | 14h         |
+
+---
+
+## Incomplete Stories
+
+All planned stories were completed this sprint. No stories carried over to Sprint 2.
+
+---
+
+## Velocity Metrics
+
+| Metric                  | Value                   |
+|-------------------------|-------------------------|
+| Stories completed        | 4                       |
+| Ideal hours committed    | 100h                    |
+| Sprint duration          | 10 days                 |
+| Story velocity           | 0.4 stories/day         |
+| Hour velocity            | 10.0 hours/day          |
+
+---
+
+## Cumulative Velocity (After Sprint 1)
+
+| Metric                        | Value           |
+|-------------------------------|-----------------|
+| Total stories completed        | 4               |
+| Total ideal hours logged       | 100h            |
+| Total sprint days elapsed      | 10              |
+| Cumulative story velocity      | 0.4 stories/day |
+| Cumulative hour velocity       | 10.0 hours/day  |
+
+---
+
+## Burnup Chart
+
+![Burnup Chart](burnup.png)
+
+---
+
+## Burnup Data
+
+| Day | Completed Hours (Actual) | Ideal Line |
+|-----|--------------------------|------------|
+| 1   | 8                        | 10         |
+| 2   | 18                       | 20         |
+| 3   | 24                       | 30         |
+| 4   | 38                       | 40         |
+| 5   | 50                       | 50         |
+| 6   | 55                       | 60         |
+| 7   | 68                       | 70         |
+| 8   | 80                       | 80         |
+| 9   | 91                       | 90         |
+| 10  | 100                      | 100        |

--- a/documentation-case-01-happy-path/test-plan.md
+++ b/documentation-case-01-happy-path/test-plan.md
@@ -1,0 +1,54 @@
+# Test Plan | Campus Event App | Team Rocket | Rev 1.0 | 2026-05-01
+
+## Test Scenarios
+
+---
+
+### Scenario 1: Successful User Registration (US-1)
+
+**Given** a new visitor is on the `/register` page  
+**When** they enter `newuser@campus.edu` and password `Secure123!` and click "Register"  
+**Then** their account is created, they are redirected to `/dashboard`, and a welcome message "Welcome, newuser!" is displayed
+
+**Inputs:** Email: `newuser@campus.edu`, Password: `Secure123!`  
+**Expected Output:** HTTP 201 response, JWT cookie set, redirect to `/dashboard`, "Welcome, newuser!" visible  
+**Result:** Pass
+
+---
+
+### Scenario 2: Login with Valid Credentials (US-2)
+
+**Given** a registered user with email `alice@campus.edu` and password `MyPass456!` is on the `/login` page  
+**When** they enter their credentials and click "Log In"  
+**Then** they are authenticated, a JWT is issued, and they are redirected to `/dashboard` showing "Welcome back, Alice"
+
+**Inputs:** Email: `alice@campus.edu`, Password: `MyPass456!`  
+**Expected Output:** HTTP 200 response, JWT cookie set, redirect to `/dashboard`, "Welcome back, Alice" visible  
+**Result:** Pass
+
+---
+
+### Scenario 3: Browse and Filter Events by Category (US-3)
+
+**Given** a logged-in student is on the `/events` page  
+**When** they select the "Academic" category filter  
+**Then** the event list refreshes and displays only events tagged "Academic" (e.g., "CS Capstone Showcase", "Math Club Lecture")
+
+**Inputs:** Category filter: `Academic`  
+**Expected Output:** Event list contains only events where `category === "Academic"`, pagination shows correct count  
+**Result:** Pass
+
+---
+
+## Unit Tests
+
+Unit tests are located in `/tests/unit/` and run via **Jest** (`npm test`).
+
+| Suite                          | File                              | Tests | Passed | Failed |
+|--------------------------------|-----------------------------------|-------|--------|--------|
+| Registration validation        | `auth/register.test.ts`           | 8     | 8      | 0      |
+| Login + lockout logic          | `auth/login.test.ts`              | 10    | 10     | 0      |
+| Event list filtering           | `events/eventList.test.ts`        | 6     | 6      | 0      |
+| RSVP toggle endpoints          | `events/rsvp.test.ts`             | 5     | 5      | 0      |
+
+**Total: 29 tests — 29 passed, 0 failed**

--- a/documentation-case-02-minimal-sprint-only/sprint-1-plan.md
+++ b/documentation-case-02-minimal-sprint-only/sprint-1-plan.md
@@ -1,0 +1,79 @@
+# Sprint 1 Plan | Task Manager App | Team Nova | Due: June 7, 2026 | Rev 1.0 | 2026-05-10
+
+## Team
+- Sam — Scrum Master
+- Priya — Product Owner
+- Leo — Developer
+- Mia — Developer
+
+## Sprint Goal
+Enable users to create, view, and complete tasks in the Task Manager App.
+
+## Capacity
+- Team available hours: 80h
+- Committed hours: 66h
+- Buffer reserved: 14h (17%)
+
+## Scrum Times
+- Tuesday 9:00am — Daily Standup
+- Thursday 9:00am — Daily Standup
+- Thursday 3:00pm — TA Visit
+- Friday 2:00pm — Sprint Review
+
+---
+
+## User Stories
+
+### US-1: Create a Task
+**As a** logged-in user, **I want to** create a new task with a title and due date, **so that** I can track what I need to do.
+
+**Acceptance Criteria:**
+1. Given I submit a title and valid due date, the task appears in my task list within 1 second.
+2. Given I submit with an empty title, I see the error "Title is required."
+
+**Tasks:**
+- [ ] Build CreateTask form component with title and date fields (4h) — Leo
+- [ ] Implement POST /api/tasks endpoint with validation (4h) — Mia
+- [ ] Write unit tests for task creation (3h) — Leo
+
+**Story Total: 11h**
+
+---
+
+### US-2: View My Tasks
+**As a** logged-in user, **I want to** see a list of all my tasks, **so that** I know what is pending.
+
+**Acceptance Criteria:**
+1. Given I navigate to /tasks, I see all my tasks sorted by due date.
+2. Given I have no tasks, I see the message "No tasks yet — create one!"
+
+**Tasks:**
+- [ ] Build TaskList component with sorting (4h) — Leo
+- [ ] Implement GET /api/tasks endpoint (3h) — Mia
+- [ ] Write unit tests for task list retrieval (3h) — Mia
+
+**Story Total: 10h**
+
+---
+
+### US-3: Mark a Task Complete
+**As a** logged-in user, **I want to** mark a task as complete, **so that** I can track my progress.
+
+**Acceptance Criteria:**
+1. Given I click "Complete" on a task, it moves to the completed section with a timestamp.
+2. Given a task is already complete, the "Complete" button is disabled.
+
+**Tasks:**
+- [ ] Add complete toggle button to TaskCard component (3h) — Leo
+- [ ] Implement PATCH /api/tasks/:id endpoint for status update (4h) — Mia
+- [ ] Write unit tests for task completion (3h) — Leo
+
+**Story Total: 10h**
+
+---
+
+## Initial Task Assignments
+- Leo: US-1 tasks 1, 3 · US-2 task 1 · US-3 tasks 1, 3
+- Mia: US-1 task 2 · US-2 tasks 2, 3 · US-3 task 2
+- Sam: Facilitation, blocker removal
+- Priya: Backlog grooming, stakeholder updates

--- a/documentation-case-02-minimal-sprint-only/sprint-1-report.md
+++ b/documentation-case-02-minimal-sprint-only/sprint-1-report.md
@@ -1,0 +1,89 @@
+# Sprint 1 Report | Task Manager App | Team Nova | Sprint End: June 7, 2026 | Rev 1.0 | 2026-06-07
+
+## Summary
+Sprint 1 completed with all three planned stories delivered.
+
+---
+
+## STOP
+
+1. **Late PR submissions** — Two PRs were submitted on the last day of the sprint, leaving insufficient time for review. This created bottlenecks and last-minute merges. We should stop holding PRs until the final day.
+
+2. **Skipping standup updates when blocked** — Team members who were blocked sometimes skipped updating in standup, which prolonged blockers. We should stop going silent when stuck — a brief "I'm blocked on X" is valuable.
+
+---
+
+## START
+
+1. **Opening PRs as drafts early** — Opening draft PRs on Day 1 of a task allows async feedback before the code is finished. This would reduce late-stage rework.
+
+2. **Posting blockers in Slack before standup** — A short async message before standup would let the team prepare solutions, making the live session more efficient.
+
+---
+
+## KEEP
+
+1. **Weekly TA visit with a prepared question list** — Bringing 3–4 focused questions to each TA visit made the sessions productive. Continue this practice every sprint.
+
+---
+
+## Completed Stories
+
+| Story ID | Title               | Hours Logged |
+|----------|---------------------|-------------|
+| US-1     | Create a Task        | 11h         |
+| US-2     | View My Tasks        | 10h         |
+| US-3     | Mark a Task Complete | 10h         |
+
+---
+
+## Incomplete Stories
+
+All planned stories were completed this sprint.
+
+---
+
+## Velocity Metrics
+
+| Metric               | Value             |
+|----------------------|-------------------|
+| Stories completed     | 3                 |
+| Ideal hours committed | 66h               |
+| Sprint duration       | 10 days           |
+| Story velocity        | 0.3 stories/day   |
+| Hour velocity         | 6.6 hours/day     |
+
+---
+
+## Cumulative Velocity (After Sprint 1)
+
+| Metric                    | Value             |
+|---------------------------|-------------------|
+| Total stories completed    | 3                 |
+| Total ideal hours logged   | 66h               |
+| Total sprint days          | 10                |
+| Cumulative story velocity  | 0.3 stories/day   |
+| Cumulative hour velocity   | 6.6 hours/day     |
+
+---
+
+## Burnup Chart
+
+![Burnup Chart](burnup.png)
+
+---
+
+## Burnup Data
+
+| Day | Completed Hours (Actual) | Ideal Line |
+|-----|--------------------------|------------|
+| 1   | 5                        | 6.6        |
+| 2   | 12                       | 13.2       |
+| 3   | 19                       | 19.8       |
+| 4   | 27                       | 26.4       |
+| 5   | 33                       | 33.0       |
+| 6   | 38                       | 39.6       |
+| 7   | 46                       | 46.2       |
+| 8   | 54                       | 52.8       |
+| 9   | 60                       | 59.4       |
+| 10  | 66                       | 66.0       |

--- a/documentation-case-03-filename-strictness/dod.md
+++ b/documentation-case-03-filename-strictness/dod.md
@@ -1,0 +1,3 @@
+# DoD
+
+Placeholder content for filename strictness test.

--- a/documentation-case-03-filename-strictness/meeting-notes.md
+++ b/documentation-case-03-filename-strictness/meeting-notes.md
@@ -1,0 +1,3 @@
+# Meeting Notes
+
+Placeholder content for filename strictness test.

--- a/documentation-case-03-filename-strictness/releaseplan.md
+++ b/documentation-case-03-filename-strictness/releaseplan.md
@@ -1,0 +1,3 @@
+# Release Plan
+
+Placeholder content for filename strictness test.

--- a/documentation-case-03-filename-strictness/sprint-01-plan.md
+++ b/documentation-case-03-filename-strictness/sprint-01-plan.md
@@ -1,0 +1,3 @@
+# Sprint 01 Plan
+
+Placeholder content for filename strictness test.

--- a/documentation-case-03-filename-strictness/sprint-one-plan.md
+++ b/documentation-case-03-filename-strictness/sprint-one-plan.md
@@ -1,0 +1,3 @@
+# Sprint One Plan
+
+Placeholder content for filename strictness test.

--- a/documentation-case-03-filename-strictness/sprint1-plan.md
+++ b/documentation-case-03-filename-strictness/sprint1-plan.md
@@ -1,0 +1,3 @@
+# Sprint 1 Plan
+
+Placeholder content for filename strictness test.

--- a/documentation-case-04-sprint-plan-strong/code-standards.md
+++ b/documentation-case-04-sprint-plan-strong/code-standards.md
@@ -1,0 +1,17 @@
+# Code Standards | Campus Event App | Team Rocket | Rev 1.0 | 2026-05-01
+
+## Style Guide
+Follows [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html) and Airbnb ESLint config.
+
+## Naming
+- Booleans use `is`/`has` prefix (e.g., `isLoading`, `hasError`)
+- Functions named verb+noun (e.g., `fetchEvents`, `validateEmail`)
+- No magic numbers — use named constants
+
+## Formatting
+- 2-space indentation, opening brace same line, single quotes for strings
+
+## React
+- Components in PascalCase, hooks prefixed with `use`
+
+This repo uses TypeScript (strict mode) and React 18.

--- a/documentation-case-04-sprint-plan-strong/definition-of-done.md
+++ b/documentation-case-04-sprint-plan-strong/definition-of-done.md
@@ -1,0 +1,11 @@
+# Definition of Done | Campus Event App | Team Rocket | Rev 1.0 | 2026-05-01
+
+## Task Level
+- Code reviewed by at least one team member before merging into main
+- All unit tests pass (`npm test` returns 0 failures)
+- No ESLint errors (`npm run lint` passes)
+
+## User Story Level
+- All tasks marked complete and meet Task-Level DoD
+- All acceptance criteria tested and results documented
+- Feature approved by Product Owner

--- a/documentation-case-04-sprint-plan-strong/release-plan.md
+++ b/documentation-case-04-sprint-plan-strong/release-plan.md
@@ -1,0 +1,21 @@
+# Release Plan | Campus Event App | Team Rocket | Release: MVP v1.0 | Release Date: June 14, 2026 | Rev 1.0 | 2026-05-01
+
+## High-Level Goals
+1. Deliver user registration, login, and event browsing by June 14.
+2. Achieve 80% unit test coverage before release.
+
+## User Stories
+| ID   | Story                                                                           | Points | Sprint   | Priority |
+|------|---------------------------------------------------------------------------------|--------|----------|----------|
+| US-1 | As a new user, I want to register so that I can access the platform             | 5      | Sprint 1 | High     |
+| US-2 | As a registered user, I want to log in so that I can view my dashboard          | 5      | Sprint 1 | High     |
+| US-3 | As a student, I want to browse events so that I can find relevant ones          | 8      | Sprint 1 | High     |
+
+## Capacity Check
+- Team velocity: 20 story points per sprint
+- Sprint 1 commitment: 18 points — within capacity
+
+## Product Backlog (Not In This Release)
+| ID   | Story                                                                 | Notes           |
+|------|-----------------------------------------------------------------------|-----------------|
+| US-4 | As an organizer, I want to create events so students can discover them | Deferred to v1.1 |

--- a/documentation-case-04-sprint-plan-strong/sprint-1-plan.md
+++ b/documentation-case-04-sprint-plan-strong/sprint-1-plan.md
@@ -1,0 +1,79 @@
+# Sprint 1 Plan | Campus Event App | Team Rocket | Due: May 30, 2026 | Rev 1.0 | 2026-05-01
+
+## Team
+- Alice — Scrum Master
+- Bob — Product Owner
+- Carol — Developer
+- Dave — Developer
+
+## Sprint Goal
+Deliver user registration, login, and event browsing for the MVP demo.
+
+## Capacity
+- Team available hours: 90h
+- Committed hours: 75h
+- Buffer reserved: 15h (17%)
+
+## Scrum Times
+- Monday 10:00am — Daily Standup
+- Wednesday 10:00am — Daily Standup
+- Thursday 2:00pm — TA Visit
+- Friday 10:00am — Sprint Review
+
+---
+
+## User Stories
+
+### US-1: User Registration
+**As a** new user, **I want to** register an account, **so that** I can access the platform.
+
+**Acceptance Criteria:**
+1. Given I submit a valid email and password, then my account is created and I am redirected to the dashboard.
+2. Given I submit a duplicate email, then I see the error "An account with this email already exists."
+
+**Tasks:**
+- [ ] Code registration form component with email/password fields and validation (4h) — Carol
+- [ ] Write POST /api/auth/register endpoint with email uniqueness check (6h) — Dave
+- [ ] Design error state UI for duplicate email and empty fields (2h) — Carol
+
+**Story Total: 12h**
+
+---
+
+### US-2: User Login
+**As a** registered user, **I want to** log in, **so that** I can view my personalized dashboard.
+
+**Acceptance Criteria:**
+1. Given I enter valid credentials, then I am authenticated and redirected to my dashboard.
+2. Given I enter an incorrect password, then I see the error "Invalid email or password."
+
+**Tasks:**
+- [ ] Code login form component with field validation (3h) — Carol
+- [ ] Write POST /api/auth/login endpoint with JWT issuance (5h) — Dave
+- [ ] Design redirect logic from login to dashboard (2h) — Carol
+
+**Story Total: 10h**
+
+---
+
+### US-3: Browse Upcoming Events
+**As a** student, **I want to** browse upcoming events, **so that** I can find ones relevant to my interests.
+
+**Acceptance Criteria:**
+1. Given I am on the events page, then I see events sorted by date with title, date, and location.
+2. Given I filter by category, then only matching events are displayed.
+
+**Tasks:**
+- [ ] Code EventList component with pagination and category filter (5h) — Carol
+- [ ] Write GET /api/events endpoint with category and pagination params (4h) — Dave
+- [ ] Design category filter UI with clear active state (2h) — Carol
+
+**Story Total: 11h**
+
+---
+
+## Initial Task Assignments
+- Carol: US-1 tasks 1, 3 · US-2 tasks 1, 3 · US-3 tasks 1, 3
+- Dave: US-1 task 2 · US-2 task 2 · US-3 task 2
+- Bob: Backlog grooming
+- Alice: Standup facilitation, blocker removal

--- a/documentation-case-04-sprint-plan-strong/sprint-1-report.md
+++ b/documentation-case-04-sprint-plan-strong/sprint-1-report.md
@@ -1,0 +1,55 @@
+# Sprint 1 Report | Campus Event App | Team Rocket | Sprint End: May 30, 2026 | Rev 1.0 | 2026-05-30
+
+## STOP
+1. **Skipping PR descriptions** — PRs merged without context slowed reviews. We should always include a one-line summary so reviewers understand the intent without reading the full diff.
+
+## START
+1. **Async Slack standup thread** — Opening a short written update before the live standup would keep meetings under 15 minutes.
+
+## KEEP
+1. **Pair programming on complex endpoints** — Pairing reduced bugs on the login endpoint. Continue this for backend tasks with security implications.
+
+## Completed Stories
+| Story ID | Title | Hours |
+|----------|-------|-------|
+| US-1 | User Registration | 12h |
+| US-2 | User Login | 10h |
+| US-3 | Browse Upcoming Events | 11h |
+
+## Incomplete Stories
+All planned stories were completed this sprint.
+
+## Velocity Metrics
+| Metric | Value |
+|--------|-------|
+| Stories completed | 3 |
+| Ideal hours committed | 75h |
+| Sprint duration | 10 days |
+| Story velocity | 0.3 stories/day |
+| Hour velocity | 7.5 hours/day |
+
+## Cumulative Velocity (After Sprint 1)
+| Metric | Value |
+|--------|-------|
+| Total stories completed | 3 |
+| Total ideal hours | 75h |
+| Total sprint days | 10 |
+| Cumulative story velocity | 0.3 stories/day |
+| Cumulative hour velocity | 7.5 hours/day |
+
+## Burnup Chart
+![Burnup Chart](burnup.png)
+
+## Burnup Data
+| Day | Actual Hours | Ideal Line |
+|-----|-------------|------------|
+| 1   | 6           | 7.5        |
+| 2   | 14          | 15.0       |
+| 3   | 22          | 22.5       |
+| 4   | 29          | 30.0       |
+| 5   | 38          | 37.5       |
+| 6   | 45          | 45.0       |
+| 7   | 54          | 52.5       |
+| 8   | 62          | 60.0       |
+| 9   | 68          | 67.5       |
+| 10  | 75          | 75.0       |

--- a/documentation-case-04-sprint-plan-strong/test-plan.md
+++ b/documentation-case-04-sprint-plan-strong/test-plan.md
@@ -1,0 +1,21 @@
+# Test Plan | Campus Event App | Team Rocket | Rev 1.0 | 2026-05-01
+
+## Test Scenarios
+
+### Scenario 1: User Registration (US-1)
+**Given** a new user enters `test@campus.edu` and `Pass123!`
+**When** they click Register
+**Then** account is created and user is redirected to dashboard
+
+**Inputs:** Email: `test@campus.edu`, Password: `Pass123!`
+**Expected Output:** HTTP 201, redirect to `/dashboard`
+**Result:** Pass
+
+## Unit Tests
+Unit tests in `/tests/unit/` run via Jest (`npm test`).
+
+| Suite | Tests | Passed | Failed |
+|-------|-------|--------|--------|
+| `auth/register.test.ts` | 5 | 5 | 0 |
+
+**Total: 5 passed, 0 failed**

--- a/documentation-case-05-sprint-plan-weak/code-standards.md
+++ b/documentation-case-05-sprint-plan-weak/code-standards.md
@@ -1,0 +1,17 @@
+# Code Standards | Campus Event App | Team Rocket | Rev 1.0 | 2026-05-01
+
+## Style Guide
+Follows [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html) and Airbnb ESLint config.
+
+## Naming
+- Booleans use `is`/`has` prefix (e.g., `isLoading`, `hasError`)
+- Functions named verb+noun (e.g., `fetchEvents`, `validateEmail`)
+- No magic numbers — use named constants
+
+## Formatting
+- 2-space indentation, opening brace same line, single quotes for strings
+
+## React
+- Components in PascalCase, hooks prefixed with `use`
+
+This repo uses TypeScript (strict mode) and React 18.

--- a/documentation-case-05-sprint-plan-weak/definition-of-done.md
+++ b/documentation-case-05-sprint-plan-weak/definition-of-done.md
@@ -1,0 +1,11 @@
+# Definition of Done | Campus Event App | Team Rocket | Rev 1.0 | 2026-05-01
+
+## Task Level
+- Code reviewed by at least one team member before merging into main
+- All unit tests pass (`npm test` returns 0 failures)
+- No ESLint errors (`npm run lint` passes)
+
+## User Story Level
+- All tasks marked complete and meet Task-Level DoD
+- All acceptance criteria tested and results documented
+- Feature approved by Product Owner

--- a/documentation-case-05-sprint-plan-weak/release-plan.md
+++ b/documentation-case-05-sprint-plan-weak/release-plan.md
@@ -1,0 +1,20 @@
+# Release Plan | Campus Event App | Team Rocket | Release: MVP v1.0 | Release Date: June 14, 2026 | Rev 1.0 | 2026-05-01
+
+## High-Level Goals
+1. Deliver core features by June 14.
+2. Achieve 80% unit test coverage before release.
+
+## User Stories
+| ID   | Story                                                                  | Points | Sprint   | Priority |
+|------|------------------------------------------------------------------------|--------|----------|----------|
+| US-1 | As a new user, I want to register so that I can access the platform    | 5      | Sprint 1 | High     |
+| US-2 | As a registered user, I want to log in so that I can view my dashboard | 5      | Sprint 1 | High     |
+
+## Capacity Check
+- Team velocity: 12 story points per sprint
+- Sprint 1 commitment: 10 points — within capacity
+
+## Product Backlog (Not In This Release)
+| ID   | Story                                                          | Notes           |
+|------|----------------------------------------------------------------|-----------------|
+| US-3 | As an organizer, I want to create events for students to find  | Deferred to v1.1 |

--- a/documentation-case-05-sprint-plan-weak/sprint-1-plan.md
+++ b/documentation-case-05-sprint-plan-weak/sprint-1-plan.md
@@ -1,0 +1,63 @@
+# Sprint 1 Plan | Campus Event App | Team Rocket | Due: May 30, 2026 | Rev 1.0 | 2026-05-01
+
+## Team
+- Alice — Scrum Master
+- Bob — Product Owner
+- Carol — Developer
+- Dave — Developer
+
+## Sprint Goal
+Build out the backend infrastructure and core application features for the platform.
+
+## Capacity
+- Team available hours: 80h
+- Committed hours: 80h
+
+## Scrum Times
+- Monday 10:00am — Daily Standup
+- Wednesday 10:00am — Daily Standup
+- Thursday 2:00pm — TA Visit
+- Friday 10:00am — Sprint Review
+
+---
+
+## User Stories
+
+### US-1: Database Setup
+**As a** developer, **I want to** set up the database schema, **so that** the backend can persist data.
+
+**Tasks:**
+- Backend work (4h) — Dave
+- Do stuff (3h) — Carol
+
+**Story Total: 7h**
+
+---
+
+### US-2: Full Social Media Platform
+**As a** user, **I want a** complete fully-featured social media platform with messaging, posts, stories, reels, marketplace, and live streaming, **so that** I can do everything social on one app.
+
+**Tasks:**
+- Do stuff (3h) — Carol
+- Help team (2h) — Dave
+
+**Story Total: 5h**
+
+---
+
+### US-3: Backend API
+**As a** developer, **I want to** write the backend API, **so that** the frontend can communicate with the database.
+
+**Tasks:**
+- Backend work (5h) — Dave
+- Testing (6h) — Carol
+
+**Story Total: 11h**
+
+---
+
+## Initial Task Assignments
+- Carol: US-1 task 2 · US-2 task 1 · US-3 task 2
+- Dave: US-1 task 1 · US-2 task 2 · US-3 task 1
+- Bob: Backlog grooming
+- Alice: Standup facilitation

--- a/documentation-case-05-sprint-plan-weak/sprint-1-report.md
+++ b/documentation-case-05-sprint-plan-weak/sprint-1-report.md
@@ -1,0 +1,54 @@
+# Sprint 1 Report | Campus Event App | Team Rocket | Sprint End: May 30, 2026 | Rev 1.0 | 2026-05-30
+
+## STOP
+1. **Late PRs** — PRs submitted on the last day created review bottlenecks. We should open PRs earlier.
+
+## START
+1. **Async Slack updates before standup** — Would keep live meetings shorter.
+
+## KEEP
+1. **TA visit with prepared questions** — Effective; continue each sprint.
+
+## Completed Stories
+| Story ID | Title | Hours |
+|----------|-------|-------|
+| US-1 | Database Setup | 7h |
+| US-2 | Full Social Media Platform | 5h |
+| US-3 | Backend API | 11h |
+
+## Incomplete Stories
+All planned stories were completed this sprint.
+
+## Velocity Metrics
+| Metric | Value |
+|--------|-------|
+| Stories completed | 3 |
+| Ideal hours committed | 80h |
+| Sprint duration | 10 days |
+| Story velocity | 0.3 stories/day |
+| Hour velocity | 8.0 hours/day |
+
+## Cumulative Velocity (After Sprint 1)
+| Metric | Value |
+|--------|-------|
+| Cumulative stories | 3 |
+| Cumulative hours | 80h |
+| Cumulative story velocity | 0.3 stories/day |
+| Cumulative hour velocity | 8.0 hours/day |
+
+## Burnup Chart
+![Burnup Chart](burnup.png)
+
+## Burnup Data
+| Day | Actual Hours | Ideal Line |
+|-----|-------------|------------|
+| 1   | 7           | 8          |
+| 2   | 15          | 16         |
+| 3   | 24          | 24         |
+| 4   | 31          | 32         |
+| 5   | 40          | 40         |
+| 6   | 48          | 48         |
+| 7   | 56          | 56         |
+| 8   | 64          | 64         |
+| 9   | 72          | 72         |
+| 10  | 80          | 80         |

--- a/documentation-case-05-sprint-plan-weak/test-plan.md
+++ b/documentation-case-05-sprint-plan-weak/test-plan.md
@@ -1,0 +1,21 @@
+# Test Plan | Campus Event App | Team Rocket | Rev 1.0 | 2026-05-01
+
+## Test Scenarios
+
+### Scenario 1: User Registration (US-1)
+**Given** a new user enters `test@campus.edu` and `Pass123!`
+**When** they click Register
+**Then** account is created and user is redirected to dashboard
+
+**Inputs:** Email: `test@campus.edu`, Password: `Pass123!`
+**Expected Output:** HTTP 201, redirect to `/dashboard`
+**Result:** Pass
+
+## Unit Tests
+Unit tests in `/tests/unit/` run via Jest (`npm test`).
+
+| Suite | Tests | Passed | Failed |
+|-------|-------|--------|--------|
+| `auth/register.test.ts` | 5 | 5 | 0 |
+
+**Total: 5 passed, 0 failed**

--- a/documentation-case-06-sprint-report-chart-no-data/sprint-1-plan.md
+++ b/documentation-case-06-sprint-report-chart-no-data/sprint-1-plan.md
@@ -1,0 +1,79 @@
+# Sprint 1 Plan | Campus Event App | Team Rocket | Due: May 30, 2026 | Rev 1.0 | 2026-05-01
+
+## Team
+- Alice — Scrum Master
+- Bob — Product Owner
+- Carol — Developer
+- Dave — Developer
+
+## Sprint Goal
+Deliver user registration, login, and event browsing for the MVP demo.
+
+## Capacity
+- Team available hours: 90h
+- Committed hours: 75h
+- Buffer reserved: 15h (17%)
+
+## Scrum Times
+- Monday 10:00am — Daily Standup
+- Wednesday 10:00am — Daily Standup
+- Thursday 2:00pm — TA Visit
+- Friday 10:00am — Sprint Review
+
+---
+
+## User Stories
+
+### US-1: User Registration
+**As a** new user, **I want to** register an account, **so that** I can access the platform.
+
+**Acceptance Criteria:**
+1. Given I submit valid credentials, then my account is created and I am redirected to the dashboard.
+2. Given I submit a duplicate email, then I see an error message.
+
+**Tasks:**
+- [ ] Code registration form component (4h) — Carol
+- [ ] Write POST /api/auth/register endpoint (6h) — Dave
+- [ ] Write unit tests for registration (3h) — Carol
+
+**Story Total: 13h**
+
+---
+
+### US-2: User Login
+**As a** registered user, **I want to** log in, **so that** I can view my dashboard.
+
+**Acceptance Criteria:**
+1. Given valid credentials, I am redirected to my dashboard.
+2. Given invalid credentials, I see an error message.
+
+**Tasks:**
+- [ ] Code login form component (3h) — Carol
+- [ ] Write POST /api/auth/login endpoint (5h) — Dave
+- [ ] Write unit tests for login (3h) — Carol
+
+**Story Total: 11h**
+
+---
+
+### US-3: Browse Upcoming Events
+**As a** student, **I want to** browse upcoming events, **so that** I can find relevant ones.
+
+**Acceptance Criteria:**
+1. Given I am on the events page, I see events sorted by date.
+2. Given I filter by category, only matching events are shown.
+
+**Tasks:**
+- [ ] Code EventList component with filter (5h) — Carol
+- [ ] Write GET /api/events endpoint (4h) — Dave
+- [ ] Write unit tests for event list (3h) — Carol
+
+**Story Total: 12h**
+
+---
+
+## Initial Task Assignments
+- Carol: US-1 tasks 1, 3 · US-2 tasks 1, 3 · US-3 tasks 1, 3
+- Dave: US-1 task 2 · US-2 task 2 · US-3 task 2
+- Bob: Backlog grooming
+- Alice: Standup facilitation

--- a/documentation-case-06-sprint-report-chart-no-data/sprint-1-report.md
+++ b/documentation-case-06-sprint-report-chart-no-data/sprint-1-report.md
@@ -1,0 +1,68 @@
+# Sprint 1 Report | Campus Event App | Team Rocket | Sprint End: May 30, 2026 | Rev 1.0 | 2026-05-30
+
+## Summary
+Sprint 1 concluded with all three planned stories completed.
+
+---
+
+## STOP
+
+1. **Late PR submissions** — Two PRs were submitted on the final sprint day, leaving no time for proper review. We should stop waiting until the end of the sprint to open PRs.
+
+---
+
+## START
+
+1. **Opening draft PRs early** — Creating draft PRs on Day 1 of a task allows async feedback before completion, reducing late-stage rework.
+
+---
+
+## KEEP
+
+1. **TA visit with prepared questions** — Bringing a written agenda to each TA session made the time productive. Continue preparing 3–4 questions before each visit.
+
+---
+
+## Completed Stories
+
+| Story ID | Title                  | Hours Logged |
+|----------|------------------------|-------------|
+| US-1     | User Registration       | 25h         |
+| US-2     | User Login              | 25h         |
+| US-3     | Browse Upcoming Events  | 25h         |
+
+---
+
+## Incomplete Stories
+
+All planned stories completed this sprint. No stories carried over.
+
+---
+
+## Velocity Metrics
+
+| Metric                  | Value               |
+|-------------------------|---------------------|
+| Stories completed        | 3                   |
+| Ideal hours committed    | 75h                 |
+| Sprint duration          | 10 days             |
+| Story velocity           | 0.3 stories/day     |
+| Hour velocity            | 7.5 hours/day       |
+
+---
+
+## Cumulative Velocity (After Sprint 1)
+
+| Metric                        | Value           |
+|-------------------------------|-----------------|
+| Total stories completed        | 3               |
+| Total ideal hours logged       | 75h             |
+| Total sprint days elapsed      | 10              |
+| Cumulative story velocity      | 0.3 stories/day |
+| Cumulative hour velocity       | 7.5 hours/day   |
+
+---
+
+## Burnup Chart
+
+![Burnup Chart](burnup.png)

--- a/documentation-case-07-dod-strong/code-standards.md
+++ b/documentation-case-07-dod-strong/code-standards.md
@@ -1,0 +1,10 @@
+# Code Standards
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Style Guide
+We follow the Google TypeScript Style Guide, enforced via ESLint.
+
+## Rules
+- Use `const` by default; use `let` only when reassignment is needed
+- All functions must have explicit return types
+- No `any` types; use `unknown` with type guards instead

--- a/documentation-case-07-dod-strong/definition-of-done.md
+++ b/documentation-case-07-dod-strong/definition-of-done.md
@@ -1,0 +1,21 @@
+# Definition of Done
+**Product:** Campus Event App | **Team:** Team Rocket | **Date:** May 2026
+
+## Task-Level Definition of Done
+*Did we build it right? (Engineering perspective)*
+
+- [ ] Code reviewed by at least one team member via pull request before merging to main
+- [ ] All unit tests pass (npm test returns 0 failures in CI)
+- [ ] Code committed and pushed to the main branch via pull request
+- [ ] ESLint passes with zero errors (npm run lint)
+- [ ] External/public API methods documented with JSDoc comments
+- [ ] No regression failures in existing test suite
+
+## User Story-Level Definition of Done
+*Did we build the right thing? (User perspective)*
+
+- [ ] All tasks for the user story are marked complete
+- [ ] All acceptance criteria tests pass and results are documented
+- [ ] Feature reviewed and approved by Product Owner in sprint review
+- [ ] User-facing help text or documentation updated where applicable
+- [ ] Feature deployed to staging environment and smoke-tested

--- a/documentation-case-07-dod-strong/release-plan.md
+++ b/documentation-case-07-dod-strong/release-plan.md
@@ -1,0 +1,9 @@
+# Release Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Planned Releases
+
+| User Story | Description | Sprint |
+|---|---|---|
+| US-01 | View upcoming campus events | Sprint 1 |
+| US-02 | Filter events by category | Sprint 2 |

--- a/documentation-case-07-dod-strong/sprint-1-plan.md
+++ b/documentation-case-07-dod-strong/sprint-1-plan.md
@@ -1,0 +1,12 @@
+# Sprint 1 Plan
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1
+
+## User Stories
+
+### US-01: View upcoming campus events
+As a student, I want to see a list of upcoming campus events so I can plan my schedule.
+
+**Tasks:**
+- [ ] Create EventList component (Alice, 3h)
+- [ ] Fetch events from API endpoint (Bob, 2h)
+- [ ] Write unit tests for EventList (Alice, 1h)

--- a/documentation-case-07-dod-strong/sprint-1-report.md
+++ b/documentation-case-07-dod-strong/sprint-1-report.md
@@ -1,0 +1,17 @@
+# Sprint 1 Report
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1
+
+## Velocity
+Planned: 8 story points | Completed: 7 story points
+
+## Burnup Chart
+![Sprint 1 Burnup](burnup-sprint1.png)
+Scope line: 8 points. Completion line reached 7 by day 10.
+
+## Retrospective
+
+**STOP:** Skipping PR descriptions — reviewers had to ask for context.
+
+**START:** Adding acceptance criteria to each task before sprint begins.
+
+**KEEP:** Daily standups at 9am; team finds them focused and useful.

--- a/documentation-case-07-dod-strong/test-plan.md
+++ b/documentation-case-07-dod-strong/test-plan.md
@@ -1,0 +1,13 @@
+# Test Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Acceptance Criteria Tests
+
+### US-01: View upcoming campus events
+
+**Given** the student opens the app,
+**When** the event list loads,
+**Then** at least 3 upcoming events are displayed with title, date, and location.
+
+## Unit Tests
+Unit tests live in `src/__tests__/`. Run with `npm test`. All tests must pass before merging.

--- a/documentation-case-08-dod-weak/code-standards.md
+++ b/documentation-case-08-dod-weak/code-standards.md
@@ -1,0 +1,10 @@
+# Code Standards
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Style Guide
+We follow the Google TypeScript Style Guide, enforced via ESLint.
+
+## Rules
+- Use `const` by default; use `let` only when reassignment is needed
+- All functions must have explicit return types
+- No `any` types; use `unknown` with type guards instead

--- a/documentation-case-08-dod-weak/definition-of-done.md
+++ b/documentation-case-08-dod-weak/definition-of-done.md
@@ -1,0 +1,10 @@
+# Definition of Done
+**Team:** Team Rocket
+
+## Our Definition of Done
+
+- Quality is good
+- Feature works correctly
+- Code is clean and readable
+- Team is happy with the result
+- Everything is done

--- a/documentation-case-08-dod-weak/release-plan.md
+++ b/documentation-case-08-dod-weak/release-plan.md
@@ -1,0 +1,9 @@
+# Release Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Planned Releases
+
+| User Story | Description | Sprint |
+|---|---|---|
+| US-01 | View upcoming campus events | Sprint 1 |
+| US-02 | Filter events by category | Sprint 2 |

--- a/documentation-case-08-dod-weak/sprint-1-plan.md
+++ b/documentation-case-08-dod-weak/sprint-1-plan.md
@@ -1,0 +1,12 @@
+# Sprint 1 Plan
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1
+
+## User Stories
+
+### US-01: View upcoming campus events
+As a student, I want to see a list of upcoming campus events so I can plan my schedule.
+
+**Tasks:**
+- [ ] Create EventList component (Alice, 3h)
+- [ ] Fetch events from API endpoint (Bob, 2h)
+- [ ] Write unit tests for EventList (Alice, 1h)

--- a/documentation-case-08-dod-weak/sprint-1-report.md
+++ b/documentation-case-08-dod-weak/sprint-1-report.md
@@ -1,0 +1,17 @@
+# Sprint 1 Report
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1
+
+## Velocity
+Planned: 8 story points | Completed: 7 story points
+
+## Burnup Chart
+![Sprint 1 Burnup](burnup-sprint1.png)
+Scope line: 8 points. Completion line reached 7 by day 10.
+
+## Retrospective
+
+**STOP:** Skipping PR descriptions — reviewers had to ask for context.
+
+**START:** Adding acceptance criteria to each task before sprint begins.
+
+**KEEP:** Daily standups at 9am; team finds them focused and useful.

--- a/documentation-case-08-dod-weak/test-plan.md
+++ b/documentation-case-08-dod-weak/test-plan.md
@@ -1,0 +1,13 @@
+# Test Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Acceptance Criteria Tests
+
+### US-01: View upcoming campus events
+
+**Given** the student opens the app,
+**When** the event list loads,
+**Then** at least 3 upcoming events are displayed with title, date, and location.
+
+## Unit Tests
+Unit tests live in `src/__tests__/`. Run with `npm test`. All tests must pass before merging.

--- a/documentation-case-09-code-standards-strong/code-standards.md
+++ b/documentation-case-09-code-standards-strong/code-standards.md
@@ -1,0 +1,26 @@
+# Code Standards
+**Product:** Campus Event App | **Team:** Team Rocket | **Stack:** TypeScript, React, Next.js
+
+## Style Guide
+We follow the **Google TypeScript Style Guide** and enforce it via **ESLint with Airbnb config** (`eslint-config-airbnb-typescript`). All PRs must pass `npm run lint` with zero errors.
+
+## Naming Conventions
+- **Variables:** Use descriptive names that reveal intent. Boolean variables must use `is` or `has` prefix (e.g., `isLoggedIn`, `hasPermission`, `isLoading`)
+- **Functions/Methods:** Use verb+noun pattern that describes what the function does (e.g., `fetchUserById`, `validateEventDate`, `renderEventCard`). Avoid vague verbs: no `handleData()`, `processStuff()`, `doThing()`
+- **Constants:** Use UPPER_SNAKE_CASE for module-level constants (e.g., `MAX_EVENT_CAPACITY = 500`)
+- **React Components:** PascalCase (e.g., `EventCard`, `UserProfile`)
+- **React Hooks:** Prefix with `use` (e.g., `useEventData`, `useAuthStatus`)
+- **No magic numbers:** Replace inline numbers with named constants
+
+## Formatting
+- **Indentation:** 2 spaces (no tabs)
+- **Quotes:** Single quotes for strings, except JSX attributes use double quotes
+- **Braces:** Opening brace on same line as declaration (`if (x) {`)
+- **Line length:** Maximum 100 characters
+- **Semicolons:** Required at end of statements
+
+## Best Practices
+- **DRY:** Extract repeated logic into utility functions. No copy-paste code blocks
+- **Single Responsibility:** Each function does one thing. If you can't describe it in one sentence, split it
+- **Clarity over cleverness:** Prefer readable code over clever one-liners. Future readers matter more than character count
+- **No commented-out code:** Delete dead code; use git history to recover it

--- a/documentation-case-09-code-standards-strong/definition-of-done.md
+++ b/documentation-case-09-code-standards-strong/definition-of-done.md
@@ -1,0 +1,14 @@
+# Definition of Done
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Task-Level Definition of Done
+
+- [ ] Code reviewed by at least one team member via pull request before merging to main
+- [ ] All unit tests pass (npm test returns 0 failures in CI)
+- [ ] ESLint passes with zero errors (npm run lint)
+
+## User Story-Level Definition of Done
+
+- [ ] All tasks for the user story are marked complete
+- [ ] All acceptance criteria tests pass and results are documented
+- [ ] Feature reviewed and approved by Product Owner in sprint review

--- a/documentation-case-09-code-standards-strong/release-plan.md
+++ b/documentation-case-09-code-standards-strong/release-plan.md
@@ -1,0 +1,9 @@
+# Release Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Planned Releases
+
+| User Story | Description | Sprint |
+|---|---|---|
+| US-01 | View upcoming campus events | Sprint 1 |
+| US-02 | Filter events by category | Sprint 2 |

--- a/documentation-case-09-code-standards-strong/sprint-1-plan.md
+++ b/documentation-case-09-code-standards-strong/sprint-1-plan.md
@@ -1,0 +1,12 @@
+# Sprint 1 Plan
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1
+
+## User Stories
+
+### US-01: View upcoming campus events
+As a student, I want to see a list of upcoming campus events so I can plan my schedule.
+
+**Tasks:**
+- [ ] Create EventList component (Alice, 3h)
+- [ ] Fetch events from API endpoint (Bob, 2h)
+- [ ] Write unit tests for EventList (Alice, 1h)

--- a/documentation-case-09-code-standards-strong/sprint-1-report.md
+++ b/documentation-case-09-code-standards-strong/sprint-1-report.md
@@ -1,0 +1,17 @@
+# Sprint 1 Report
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1
+
+## Velocity
+Planned: 8 story points | Completed: 7 story points
+
+## Burnup Chart
+![Sprint 1 Burnup](burnup-sprint1.png)
+Scope line: 8 points. Completion line reached 7 by day 10.
+
+## Retrospective
+
+**STOP:** Skipping PR descriptions — reviewers had to ask for context.
+
+**START:** Adding acceptance criteria to each task before sprint begins.
+
+**KEEP:** Daily standups at 9am; team finds them focused and useful.

--- a/documentation-case-09-code-standards-strong/test-plan.md
+++ b/documentation-case-09-code-standards-strong/test-plan.md
@@ -1,0 +1,13 @@
+# Test Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Acceptance Criteria Tests
+
+### US-01: View upcoming campus events
+
+**Given** the student opens the app,
+**When** the event list loads,
+**Then** at least 3 upcoming events are displayed with title, date, and location.
+
+## Unit Tests
+Unit tests live in `src/__tests__/`. Run with `npm test`. All tests must pass before merging.

--- a/documentation-case-10-code-standards-generic/code-standards.md
+++ b/documentation-case-10-code-standards-generic/code-standards.md
@@ -1,0 +1,12 @@
+# Code Standards
+**Team:** Team Rocket
+
+## Our Coding Standards
+
+- Write clean code
+- Use meaningful variable names
+- Keep functions short and focused
+- Don't repeat yourself
+- Comment your code where necessary
+- Make sure code works before committing
+- Be consistent

--- a/documentation-case-10-code-standards-generic/definition-of-done.md
+++ b/documentation-case-10-code-standards-generic/definition-of-done.md
@@ -1,0 +1,14 @@
+# Definition of Done
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Task-Level Definition of Done
+
+- [ ] Code reviewed by at least one team member via pull request before merging to main
+- [ ] All unit tests pass (npm test returns 0 failures in CI)
+- [ ] ESLint passes with zero errors (npm run lint)
+
+## User Story-Level Definition of Done
+
+- [ ] All tasks for the user story are marked complete
+- [ ] All acceptance criteria tests pass and results are documented
+- [ ] Feature reviewed and approved by Product Owner in sprint review

--- a/documentation-case-10-code-standards-generic/release-plan.md
+++ b/documentation-case-10-code-standards-generic/release-plan.md
@@ -1,0 +1,9 @@
+# Release Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Planned Releases
+
+| User Story | Description | Sprint |
+|---|---|---|
+| US-01 | View upcoming campus events | Sprint 1 |
+| US-02 | Filter events by category | Sprint 2 |

--- a/documentation-case-10-code-standards-generic/sprint-1-plan.md
+++ b/documentation-case-10-code-standards-generic/sprint-1-plan.md
@@ -1,0 +1,12 @@
+# Sprint 1 Plan
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1
+
+## User Stories
+
+### US-01: View upcoming campus events
+As a student, I want to see a list of upcoming campus events so I can plan my schedule.
+
+**Tasks:**
+- [ ] Create EventList component (Alice, 3h)
+- [ ] Fetch events from API endpoint (Bob, 2h)
+- [ ] Write unit tests for EventList (Alice, 1h)

--- a/documentation-case-10-code-standards-generic/sprint-1-report.md
+++ b/documentation-case-10-code-standards-generic/sprint-1-report.md
@@ -1,0 +1,17 @@
+# Sprint 1 Report
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1
+
+## Velocity
+Planned: 8 story points | Completed: 7 story points
+
+## Burnup Chart
+![Sprint 1 Burnup](burnup-sprint1.png)
+Scope line: 8 points. Completion line reached 7 by day 10.
+
+## Retrospective
+
+**STOP:** Skipping PR descriptions — reviewers had to ask for context.
+
+**START:** Adding acceptance criteria to each task before sprint begins.
+
+**KEEP:** Daily standups at 9am; team finds them focused and useful.

--- a/documentation-case-10-code-standards-generic/test-plan.md
+++ b/documentation-case-10-code-standards-generic/test-plan.md
@@ -1,0 +1,13 @@
+# Test Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Acceptance Criteria Tests
+
+### US-01: View upcoming campus events
+
+**Given** the student opens the app,
+**When** the event list loads,
+**Then** at least 3 upcoming events are displayed with title, date, and location.
+
+## Unit Tests
+Unit tests live in `src/__tests__/`. Run with `npm test`. All tests must pass before merging.

--- a/documentation-case-11-nested-files/code-standards.md
+++ b/documentation-case-11-nested-files/code-standards.md
@@ -1,0 +1,10 @@
+# Code Standards
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Style Guide
+We follow the Google TypeScript Style Guide, enforced via ESLint.
+
+## Rules
+- Use `const` by default; use `let` only when reassignment is needed
+- All functions must have explicit return types
+- No `any` types; use `unknown` with type guards instead

--- a/documentation-case-11-nested-files/definition-of-done.md
+++ b/documentation-case-11-nested-files/definition-of-done.md
@@ -1,0 +1,14 @@
+# Definition of Done
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Task-Level Definition of Done
+
+- [ ] Code reviewed by at least one team member via pull request before merging to main
+- [ ] All unit tests pass (npm test returns 0 failures in CI)
+- [ ] ESLint passes with zero errors (npm run lint)
+
+## User Story-Level Definition of Done
+
+- [ ] All tasks for the user story are marked complete
+- [ ] All acceptance criteria tests pass and results are documented
+- [ ] Feature reviewed and approved by Product Owner in sprint review

--- a/documentation-case-11-nested-files/release-plan.md
+++ b/documentation-case-11-nested-files/release-plan.md
@@ -1,0 +1,9 @@
+# Release Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Planned Releases
+
+| User Story | Description | Sprint |
+|---|---|---|
+| US-01 | View upcoming campus events | Sprint 1 |
+| US-02 | Filter events by category | Sprint 2 |

--- a/documentation-case-11-nested-files/sprint1/sprint-1-plan.md
+++ b/documentation-case-11-nested-files/sprint1/sprint-1-plan.md
@@ -1,0 +1,40 @@
+# Sprint 1 Plan
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1 | **Dates:** May 1–14, 2026
+
+## Sprint Goal
+Enable students to discover and view upcoming campus events.
+
+## Team Capacity
+- Alice: 20h available (frontend)
+- Bob: 18h available (backend)
+- Carol: 16h available (full-stack)
+
+## User Stories
+
+### US-01: View upcoming campus events (5 pts)
+*As a student, I want to see a list of upcoming campus events so I can plan my schedule.*
+
+**Acceptance Criteria:**
+- Events displayed with title, date, time, and location
+- Events sorted by date ascending
+- Empty state shown when no events exist
+
+**Tasks:**
+- [ ] Create EventList component (Alice, 3h)
+- [ ] Create EventCard component (Alice, 2h)
+- [ ] Implement GET /api/events endpoint (Bob, 3h)
+- [ ] Write unit tests for EventList and EventCard (Carol, 2h)
+- [ ] Write integration test for GET /api/events (Bob, 1h)
+
+### US-02: Filter events by category (3 pts)
+*As a student, I want to filter events by category so I only see events relevant to me.*
+
+**Acceptance Criteria:**
+- Category filter buttons displayed above event list
+- Selecting a category shows only matching events
+- "All" option resets the filter
+
+**Tasks:**
+- [ ] Add category filter UI (Alice, 2h)
+- [ ] Implement filter logic in EventList (Carol, 2h)
+- [ ] Write unit tests for filter behavior (Carol, 1h)

--- a/documentation-case-11-nested-files/sprint1/sprint-1-report.md
+++ b/documentation-case-11-nested-files/sprint1/sprint-1-report.md
@@ -1,0 +1,17 @@
+# Sprint 1 Report
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1
+
+## Velocity
+Planned: 8 story points | Completed: 8 story points
+
+## Burnup Chart
+![Sprint 1 Burnup](burnup-sprint1.png)
+Scope line: 8 points. Completion line reached 8 by day 12.
+
+## Retrospective
+
+**STOP:** Merging PRs without waiting for CI to complete.
+
+**START:** Reviewing acceptance criteria together at sprint kick-off.
+
+**KEEP:** Pair programming sessions on complex components — very effective.

--- a/documentation-case-11-nested-files/test-plan.md
+++ b/documentation-case-11-nested-files/test-plan.md
@@ -1,0 +1,13 @@
+# Test Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Acceptance Criteria Tests
+
+### US-01: View upcoming campus events
+
+**Given** the student opens the app,
+**When** the event list loads,
+**Then** at least 3 upcoming events are displayed with title, date, and location.
+
+## Unit Tests
+Unit tests live in `src/__tests__/`. Run with `npm test`. All tests must pass before merging.

--- a/documentation-case-12-duplicate-docs/code-standards.md
+++ b/documentation-case-12-duplicate-docs/code-standards.md
@@ -1,0 +1,10 @@
+# Code Standards
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Style Guide
+We follow the Google TypeScript Style Guide, enforced via ESLint.
+
+## Rules
+- Use `const` by default; use `let` only when reassignment is needed
+- All functions must have explicit return types
+- No `any` types; use `unknown` with type guards instead

--- a/documentation-case-12-duplicate-docs/definition-of-done.md
+++ b/documentation-case-12-duplicate-docs/definition-of-done.md
@@ -1,0 +1,14 @@
+# Definition of Done
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Task-Level Definition of Done
+
+- [ ] Code reviewed by at least one team member via pull request before merging to main
+- [ ] All unit tests pass (npm test returns 0 failures in CI)
+- [ ] ESLint passes with zero errors (npm run lint)
+
+## User Story-Level Definition of Done
+
+- [ ] All tasks for the user story are marked complete
+- [ ] All acceptance criteria tests pass and results are documented
+- [ ] Feature reviewed and approved by Product Owner in sprint review

--- a/documentation-case-12-duplicate-docs/release-plan.md
+++ b/documentation-case-12-duplicate-docs/release-plan.md
@@ -1,0 +1,9 @@
+# Release Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Planned Releases
+
+| User Story | Description | Sprint |
+|---|---|---|
+| US-01 | View upcoming campus events | Sprint 1 |
+| US-02 | Filter events by category | Sprint 2 |

--- a/documentation-case-12-duplicate-docs/sprint-1-plan.md
+++ b/documentation-case-12-duplicate-docs/sprint-1-plan.md
@@ -1,0 +1,38 @@
+# Sprint 1 Plan
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1 | **Dates:** May 1–14, 2026
+
+## Sprint Goal
+Enable students to discover and view upcoming campus events.
+
+## Team Capacity
+- Alice: 20h available (frontend)
+- Bob: 18h available (backend)
+- Carol: 16h available (full-stack)
+
+## User Stories
+
+### US-01: View upcoming campus events (5 pts)
+*As a student, I want to see a list of upcoming campus events so I can plan my schedule.*
+
+**Acceptance Criteria:**
+- Events displayed with title, date, time, and location
+- Events sorted by date ascending
+- Empty state shown when no events exist
+
+**Tasks:**
+- [ ] Create EventList component (Alice, 3h)
+- [ ] Create EventCard component (Alice, 2h)
+- [ ] Implement GET /api/events endpoint (Bob, 3h)
+- [ ] Write unit tests for EventList and EventCard (Carol, 2h)
+
+### US-02: Filter events by category (3 pts)
+*As a student, I want to filter events by category so I only see events relevant to me.*
+
+**Acceptance Criteria:**
+- Category filter buttons displayed above event list
+- Selecting a category shows only matching events
+
+**Tasks:**
+- [ ] Add category filter UI (Alice, 2h)
+- [ ] Implement filter logic in EventList (Carol, 2h)
+- [ ] Write unit tests for filter behavior (Carol, 1h)

--- a/documentation-case-12-duplicate-docs/sprint-1-report.md
+++ b/documentation-case-12-duplicate-docs/sprint-1-report.md
@@ -1,0 +1,17 @@
+# Sprint 1 Report
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1
+
+## Velocity
+Planned: 8 story points | Completed: 7 story points
+
+## Burnup Chart
+![Sprint 1 Burnup](burnup-sprint1.png)
+Scope line: 8 points. Completion line reached 7 by day 10.
+
+## Retrospective
+
+**STOP:** Skipping PR descriptions — reviewers had to ask for context.
+
+**START:** Adding acceptance criteria to each task before sprint begins.
+
+**KEEP:** Daily standups at 9am; team finds them focused and useful.

--- a/documentation-case-12-duplicate-docs/subfolder/sprint-1-plan.md
+++ b/documentation-case-12-duplicate-docs/subfolder/sprint-1-plan.md
@@ -1,0 +1,33 @@
+# Sprint 1 Plan
+**Product:** Campus Event App | **Team:** Team Rocket | **Sprint:** 1 | **Dates:** May 1–14, 2026
+
+## Sprint Goal
+Deliver core event browsing functionality to students.
+
+## Team Capacity
+- Dave: 20h available (frontend)
+- Emma: 18h available (backend)
+- Frank: 16h available (full-stack)
+
+## User Stories
+
+### US-01: View upcoming campus events (5 pts)
+*As a student, I want to see a list of upcoming campus events so I can find things to do.*
+
+**Acceptance Criteria:**
+- Events list shows title, date, and location
+- List sorted newest first
+- Pagination added for more than 10 events
+
+**Tasks:**
+- [ ] Build EventFeed component (Dave, 4h)
+- [ ] Implement events API route (Emma, 3h)
+- [ ] Add pagination component (Frank, 3h)
+- [ ] Write tests for EventFeed (Dave, 2h)
+
+### US-02: RSVP to an event (3 pts)
+*As a student, I want to RSVP to an event so the organizer knows I'm attending.*
+
+**Tasks:**
+- [ ] Add RSVP button to EventCard (Dave, 2h)
+- [ ] Implement POST /api/rsvp endpoint (Emma, 2h)

--- a/documentation-case-12-duplicate-docs/test-plan.md
+++ b/documentation-case-12-duplicate-docs/test-plan.md
@@ -1,0 +1,13 @@
+# Test Plan
+**Product:** Campus Event App | **Team:** Team Rocket
+
+## Acceptance Criteria Tests
+
+### US-01: View upcoming campus events
+
+**Given** the student opens the app,
+**When** the event list loads,
+**Then** at least 3 upcoming events are displayed with title, date, and location.
+
+## Unit Tests
+Unit tests live in `src/__tests__/`. Run with `npm test`. All tests must pass before merging.


### PR DESCRIPTION
## Summary
- simplify doc discovery/classification to the fixed `documentation/` + filename rules and update the review UI ordering/details
- expand sprint plan/report and holistic doc prompts, including `user_story_count` support for sprint plans
- add 12 documentation fixture folders for manual doc-review testing and align constants coverage with the simplified pipeline

## Test plan
- [x] `npm test -- apps/dashboard/__tests__/docReview/`
- [ ] Rename `documentation-case-04-sprint-plan-strong` to `documentation` in the analyzed repo and run Doc Review in the UI
- [ ] Verify expanded checklist items, `User stories: N`, and review cards above consistency checks

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document reviews now track and display user story counts for sprint plans.
  * Enhanced review rubrics with detailed evaluation criteria for sprint planning and reporting documents.

* **Improvements**
  * Simplified document discovery to focus on `documentation/` folder containing Markdown files only.
  * Reorganized document review UI with improved card layout and conditional display for better readability.

* **Tests**
  * Updated test suites to reflect stricter document classification and discovery rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scottyUX/ts-repo-metrics/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->