### PR TITLE
fix(engine): sync cached clone with remote before reuse (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ A Next.js dashboard app in `apps/dashboard/` provides a web UI:
 
 Run with `npm run dashboard` (starts `next dev` in `apps/dashboard/`). For Vercel deployment, set `GITHUB_TOKEN` to enable API-derived git metrics when the git CLI is unavailable.
 
-**GitHub analysis & cache:** The API clones under `os.tmpdir()/repo-metrics-git-cache/` (not the app folder) so stale layouts do not poison results. Cached directories are reused only if they pass `git` validation (`checkIsRepo()`); corrupt or partial clones (e.g. interrupted download) are removed and re-cloned. The CLI still uses `.cache/ts-repo-metrics/` under the current working directory unless you pass `--no-cache`.
+**GitHub analysis & cache:** The API clones under `os.tmpdir()/repo-metrics-git-cache/` (not the app folder) so stale layouts do not poison results. Cached directories are reused only if they pass `git` validation (`checkIsRepo()`); corrupt or partial clones (e.g. interrupted download) are removed and re-cloned. Reused clones are checked against the remote tip and fetched + reset only when it changed, so reanalysis always reflects the latest commit; if the sync fails, the repo is re-cloned fresh. The CLI still uses `.cache/ts-repo-metrics/` under the current working directory unless you pass `--no-cache`.
 
 ## Project Structure
 

--- a/packages/engine/__tests__/gitClone.test.ts
+++ b/packages/engine/__tests__/gitClone.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Integration tests for src/collect/gitClone.ts using a local repo as the
+ * clone remote. Verifies that a reused cache is synced with the remote so
+ * reanalysis picks up new commits (including force-pushed history).
+ */
+
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { simpleGit } from "simple-git";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { cloneOrUseCache } from "../src/collect/gitClone.js";
+import type { ParsedGitHubUrl } from "../src/utils/githubUrl.js";
+
+const TEST_TIMEOUT = 30000;
+
+async function commitFile(
+  repoDir: string,
+  name: string,
+  content: string,
+  message: string,
+): Promise<string> {
+  writeFileSync(path.join(repoDir, name), content);
+  const git = simpleGit(repoDir);
+  await git.raw(["add", "-A"]);
+  await git.commit(message);
+  return (await git.revparse(["HEAD"])).trim();
+}
+
+describe("cloneOrUseCache", () => {
+  let remoteDir: string;
+  let cacheBase: string;
+  let parsed: ParsedGitHubUrl;
+
+  beforeEach(async () => {
+    remoteDir = mkdtempSync(path.join(os.tmpdir(), "git-clone-remote-"));
+    cacheBase = mkdtempSync(path.join(os.tmpdir(), "git-clone-cache-"));
+    const git = simpleGit(remoteDir);
+    await git.init();
+    await git.addConfig("user.name", "Test");
+    await git.addConfig("user.email", "test@example.com");
+    await git.addConfig("commit.gpgsign", "false");
+    await commitFile(remoteDir, "a.ts", "export const a = 1;\n", "initial");
+    parsed = { owner: "local", repo: "fixture", url: remoteDir };
+  });
+
+  afterEach(() => {
+    rmSync(remoteDir, { recursive: true, force: true, maxRetries: 5 });
+    rmSync(cacheBase, { recursive: true, force: true, maxRetries: 5 });
+  });
+
+  it(
+    "syncs a reused cache so new remote commits are picked up",
+    async () => {
+      const first = await cloneOrUseCache(parsed, true, cacheBase);
+      const newSha = await commitFile(
+        remoteDir,
+        "b.ts",
+        "export const b = 2;\n",
+        "add b",
+      );
+
+      const second = await cloneOrUseCache(parsed, true, cacheBase);
+
+      expect(second).toBe(first);
+      expect(existsSync(path.join(second, "b.ts"))).toBe(true);
+      const head = (await simpleGit(second).revparse(["HEAD"])).trim();
+      expect(head).toBe(newSha);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "converges a reused cache after force-pushed history",
+    async () => {
+      await cloneOrUseCache(parsed, true, cacheBase);
+      const remote = simpleGit(remoteDir);
+      writeFileSync(path.join(remoteDir, "a.ts"), "export const a = 99;\n");
+      await remote.raw(["add", "-A"]);
+      await remote.raw(["commit", "--amend", "-m", "rewritten"]);
+      const amendedSha = (await remote.revparse(["HEAD"])).trim();
+
+      const repoPath = await cloneOrUseCache(parsed, true, cacheBase);
+
+      const head = (await simpleGit(repoPath).revparse(["HEAD"])).trim();
+      expect(head).toBe(amendedSha);
+    },
+    TEST_TIMEOUT,
+  );
+});

--- a/packages/engine/src/collect/downloadZipball.ts
+++ b/packages/engine/src/collect/downloadZipball.ts
@@ -72,6 +72,8 @@ export async function getSourceFromGitHubApi(
  * Zipball has one top-level dir (owner-repo-sha); we flatten so repo root is fullPath.
  * When commitSha is provided, the cache is keyed by commit and the zipball of
  * that exact ref is downloaded, so a new push can never reuse a stale snapshot.
+ * Without commitSha the cache is never reused (a snapshot of unknown ref could
+ * be stale) and the default branch is re-downloaded.
  * @param githubToken - Optional PAT for private repository zipball download.
  * @param commitSha - Latest commit SHA of the default branch (from getSourceFromGitHubApi).
  */
@@ -82,12 +84,13 @@ export async function downloadZipball(
   githubToken?: string,
   commitSha?: string,
 ): Promise<string> {
-  const fullPath = path.resolve(baseDir, CACHE_DIR, cacheKey(parsed, commitSha));
+  const sha = commitSha?.trim() || undefined;
+  const fullPath = path.resolve(baseDir, CACHE_DIR, cacheKey(parsed, sha));
 
   const parentDir = path.dirname(fullPath);
   mkdirSync(parentDir, { recursive: true });
 
-  if (useCache && existsSync(fullPath)) {
+  if (useCache && sha && existsSync(fullPath)) {
     try {
       const entries = readdirSync(fullPath);
       if (entries.length > 0) return fullPath;
@@ -101,7 +104,7 @@ export async function downloadZipball(
   }
 
   const zipUrl = `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/zipball${
-    commitSha ? `/${commitSha}` : ""
+    sha ? `/${sha}` : ""
   }`;
   const res = await fetch(zipUrl, {
     redirect: "follow",

--- a/packages/engine/src/collect/downloadZipball.ts
+++ b/packages/engine/src/collect/downloadZipball.ts
@@ -11,8 +11,9 @@ import type { SourceInfo } from "../types/report.js";
 
 const CACHE_DIR = ".cache/ts-repo-metrics";
 
-function cacheKey(parsed: ParsedGitHubUrl): string {
-  return `${parsed.owner}-${parsed.repo}`;
+function cacheKey(parsed: ParsedGitHubUrl, commitSha?: string): string {
+  const base = `${parsed.owner}-${parsed.repo}`;
+  return commitSha ? `${base}-${commitSha.slice(0, 12)}` : base;
 }
 
 function githubApiHeaders(token?: string): Record<string, string> {
@@ -69,16 +70,19 @@ export async function getSourceFromGitHubApi(
 /**
  * Download repo as zipball and extract to cache dir. Returns path to repo root.
  * Zipball has one top-level dir (owner-repo-sha); we flatten so repo root is fullPath.
- * If useCache is true and fullPath already exists (from a prior run), returns it.
+ * When commitSha is provided, the cache is keyed by commit and the zipball of
+ * that exact ref is downloaded, so a new push can never reuse a stale snapshot.
  * @param githubToken - Optional PAT for private repository zipball download.
+ * @param commitSha - Latest commit SHA of the default branch (from getSourceFromGitHubApi).
  */
 export async function downloadZipball(
   parsed: ParsedGitHubUrl,
   baseDir: string,
   useCache: boolean = true,
   githubToken?: string,
+  commitSha?: string,
 ): Promise<string> {
-  const fullPath = path.resolve(baseDir, CACHE_DIR, cacheKey(parsed));
+  const fullPath = path.resolve(baseDir, CACHE_DIR, cacheKey(parsed, commitSha));
 
   const parentDir = path.dirname(fullPath);
   mkdirSync(parentDir, { recursive: true });
@@ -96,7 +100,9 @@ export async function downloadZipball(
     rmSync(fullPath, { recursive: true });
   }
 
-  const zipUrl = `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/zipball`;
+  const zipUrl = `https://api.github.com/repos/${parsed.owner}/${parsed.repo}/zipball${
+    commitSha ? `/${commitSha}` : ""
+  }`;
   const res = await fetch(zipUrl, {
     redirect: "follow",
     headers: githubApiHeaders(githubToken),

--- a/packages/engine/src/collect/gitClone.ts
+++ b/packages/engine/src/collect/gitClone.ts
@@ -2,7 +2,8 @@
  * Git clone module for GitHub public repos.
  *
  * Clones into .cache/ts-repo-metrics/<owner-repo> with full history.
- * Reuses cache unless --no-cache.
+ * Reuses cache unless --no-cache; reused clones are fetched and reset to the
+ * remote default branch so reanalysis picks up new commits.
  */
 
 import { existsSync, mkdirSync, rmSync } from "node:fs";
@@ -25,7 +26,41 @@ function authenticatedCloneUrl(
 }
 
 /**
- * Clone a GitHub repo or return cached path.
+ * Sync an existing clone with the remote default branch (HEAD).
+ *
+ * First compares the remote tip SHA (ls-remote) with the local HEAD and
+ * returns without touching the tree when they match. Otherwise fetches from
+ * the remote URL directly so a token rotated since the original clone still
+ * works. Reset + clean rather than pull: force-pushed branches must still
+ * converge, and files deleted upstream must leave the tree.
+ *
+ * @param repoPath - Absolute path to the cached clone.
+ * @param remote - Clone URL (possibly token-authenticated; never logged).
+ */
+async function syncCloneWithRemote(
+  repoPath: string,
+  remote: string,
+): Promise<void> {
+  const repo = simpleGit(repoPath);
+  const remoteHead = (await repo.raw(["ls-remote", remote, "HEAD"]))
+    .trim()
+    .split(/\s+/)[0];
+  const localHead = (await repo.revparse(["HEAD"])).trim();
+  if (remoteHead && remoteHead === localHead) {
+    return;
+  }
+  await repo.raw(["fetch", remote, "HEAD"]);
+  await repo.raw(["reset", "--hard", "FETCH_HEAD"]);
+  await repo.raw(["clean", "-fd"]);
+}
+
+/**
+ * Clone a GitHub repo or reuse the cached clone.
+ *
+ * A reused clone is first synced with the remote default branch so new
+ * commits are picked up; if the sync fails (unreachable remote, diverged
+ * refs), the cache is discarded and the repo is cloned fresh rather than
+ * returning a stale tree.
  *
  * @param parsed - Parsed GitHub URL.
  * @param useCache - If false, clone fresh (removes cache first).
@@ -40,6 +75,9 @@ export async function cloneOrUseCache(
   githubToken?: string,
 ): Promise<string> {
   const fullPath = path.resolve(baseDir, CACHE_DIR, cacheKey(parsed));
+
+  const cloneRemote =
+    githubToken?.trim() ? authenticatedCloneUrl(parsed, githubToken.trim()) : parsed.url;
 
   // A previous run may have left a partial tree (e.g. interrupted clone: `.git` without HEAD).
   // Reusing that path skips clone and yields 0 source files — all metrics zero.
@@ -56,7 +94,12 @@ export async function cloneOrUseCache(
   }
 
   if (useCache && existsSync(fullPath)) {
-    return fullPath;
+    try {
+      await syncCloneWithRemote(fullPath, cloneRemote);
+      return fullPath;
+    } catch {
+      rmSync(fullPath, { recursive: true, force: true });
+    }
   }
 
   if (existsSync(fullPath)) {
@@ -65,9 +108,6 @@ export async function cloneOrUseCache(
 
   const parentDir = path.dirname(fullPath);
   mkdirSync(parentDir, { recursive: true });
-
-  const cloneRemote =
-    githubToken?.trim() ? authenticatedCloneUrl(parsed, githubToken.trim()) : parsed.url;
 
   const git = simpleGit();
   await git.clone(cloneRemote, fullPath, ["--no-single-branch"]);

--- a/packages/engine/src/pipeline/analyzeFromGitHubUrl.ts
+++ b/packages/engine/src/pipeline/analyzeFromGitHubUrl.ts
@@ -76,8 +76,8 @@ export async function analyzeFromGitHubUrl(
   } catch (err) {
     if (isGitUnavailable(err)) {
       usedZipball = true;
-      repoPath = await downloadZipball(parsed, cacheDir, useCache, ghToken);
       source = await getSourceFromGitHubApi(parsed, ghToken);
+      repoPath = await downloadZipball(parsed, cacheDir, useCache, ghToken, source.commit || undefined);
     } else {
       throw err;
     }


### PR DESCRIPTION
## Summary

Reanalyzing a repo returned stale results: cached clones were reused after a validity check only (`checkIsRepo()`) and never fetched, so every reanalysis re-read whatever commit was HEAD at the first clone. Fixes #103.

## Changes

- **`gitClone.ts`** — a reused clone now compares the remote tip (`git ls-remote`) with local HEAD. If unchanged, it is returned as-is; otherwise it is fetched and `reset --hard` + `clean -fd` to converge even after force-pushes or upstream file deletions. If the sync fails, the cache is wiped and the repo cloned fresh — never returns a stale tree.
- **`downloadZipball.ts`** (fallback when git is unavailable, e.g. Vercel) — cache directory is now keyed by commit SHA and the zipball is downloaded at that exact ref, so the fallback path can't serve stale snapshots either.
- **`analyzeFromGitHubUrl.ts`** — passes the resolved commit SHA through to the zipball fallback.
- **README** — cache paragraph updated to describe the new behavior.

## Testing

- Two new deterministic tests in `packages/engine/__tests__/gitClone.test.ts` using a local temp repo as the remote: a reused cache picks up new commits, and converges after force-pushed history. No network access.
- Manually verified in the dashboard: pushed a commit, reanalyzed, and the new commit's results appear with a new `result_id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cached repository clones now automatically synchronize with remote changes; sync failures trigger fresh re-clones.
  * Repository snapshots can be fetched for exact commit SHAs to ensure analysis matches a specific commit.

* **Documentation**
  * Updated cache behavior docs clarifying validation against remote tip, re-clone on failure, and note that the CLI still uses the local cache unless --no-cache is passed.

* **Tests**
  * Added integration tests validating cache synchronization and commit-specific snapshot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->