### PR TITLE
Add SIP Sprint 1 kickoff scaffolding

### DIFF
--- a/research/.gitignore
+++ b/research/.gitignore
@@ -1,0 +1,10 @@
+# Raw and generated research data (not committed)
+research/survey/data/raw/
+research/survey/data/processed/
+research/survey/outputs/
+research/datasets/post_ai_30.csv
+research/datasets/pre_ai_baseline.csv
+research/datasets/samples/
+*.pyc
+__pycache__/
+.venv/

--- a/research/KICKOFF_CHECKLIST.md
+++ b/research/KICKOFF_CHECKLIST.md
@@ -1,0 +1,45 @@
+# SIP 2026 — Sprint 1 kickoff packet (instructor)
+
+Deliver **all items below at Week 1 kickoff** before students start story tasks. Link this checklist from the pinned GitHub Discussion: **SIP 2026 — Sprint 1 Architecture & Open Questions**.
+
+Track instructor delivery in issue **SIP-1.0** (Kickoff packet).
+
+## 1. Qualtrics export (Objective 2)
+
+- [ ] De-identified CSV export from latest student cohort
+- [ ] Data dictionary / codebook: AU, AUM, TAM items per SDLC stage (Planning → Maintenance)
+- [ ] Notes on missingness rules and expected **N** after cleaning (paper baseline **N = 85**)
+- [ ] Delivery: shared drive link **or** place file at `research/survey/data/raw/` (gitignored) and notify PM in Discussion
+
+## 2. Pre-AI repo list (Objective 3)
+
+- [ ] CSV with ~30 repos (2021 human-only baseline)
+- [ ] Columns: `owner`, `repo`, `url`, `term`, `notes`
+- [ ] Template: [`research/datasets/templates/pre_ai_baseline.template.csv`](datasets/templates/pre_ai_baseline.template.csv)
+
+## 3. Post-AI repo list (Objective 3)
+
+- [ ] Exactly **30** instructor-selected repos from current cohort / Supabase
+- [ ] Columns: `result_id`, `owner`, `repo`, `repo_url`, `course_id`, `team_name`, `commit_sha` (if known)
+- [ ] Template: [`research/datasets/templates/post_ai_30.template.csv`](datasets/templates/post_ai_30.template.csv)
+
+## 4. Cursor log sample (Objective 4)
+
+- [ ] Sanitized Cursor JSONL sample (no PII)
+- [ ] Document macOS log path(s) students should support
+- [ ] Place sample at `research/fixtures/cursor/` when ready (or shared drive link for kickoff)
+
+## 5. Access
+
+- [ ] GitHub: invite all SIP students to `scottyUX/ts-repo-metrics` and [Project 3 — AI Driven SWE Research](https://github.com/users/scottyUX/projects/3)
+- [ ] Supabase: read-only credentials or export dump for Obj 3 audit (optional if lists are pre-verified)
+- [ ] Confirm students can run `npm test` and Python 3 locally
+
+## Replication targets (Objective 2 reference)
+
+Paper statistics to reproduce are documented in [`apps/dashboard/components/research/ResearchPaperBody.tsx`](../apps/dashboard/components/research/ResearchPaperBody.tsx):
+
+- Cronbach's α per stage (AUM composites): α ≈ .665–.897
+- Friedman on AUM across stages: χ²(5) ≈ 66.13, p < .001
+- Overall Pearson AU–AUM: r ≈ 0.690
+- Stage-level AU–AUM correlations (Figure 3 / Table 4 analog)

--- a/research/datasets/README.md
+++ b/research/datasets/README.md
@@ -1,0 +1,30 @@
+# Research datasets (SIP Sprint 1 — Objective 3)
+
+Build a **cohort manifest** linking Pre-AI (2021 baseline) and Post-AI (2026) repositories for downstream structural comparison.
+
+## Layout
+
+```
+research/datasets/
+├── README.md
+├── templates/               # CSV templates for instructor lists
+├── post_ai_30.csv           # instructor-provided (kickoff)
+├── pre_ai_baseline.csv      # instructor-provided (kickoff)
+├── manifest_sprint1.csv     # student output — cohort tags
+├── audit_post_ai.md         # student output — gap analysis
+├── samples/                 # optional — subset of report JSON refs
+└── tag_cohort.py            # student script (Sprint 1)
+```
+
+## Cohort labels
+
+| `cohort` value | Meaning |
+|----------------|---------|
+| `pre_ai` | 2021 human-only baseline repo |
+| `post_ai` | 2026 Post-AI experimental repo (instructor-selected) |
+
+## Supabase reference
+
+Post-AI rows should align with `public.analyses` fields: `result_id`, `repo_url`, `commit_sha`, `course_id`, `team_name`, `report_json`.
+
+See [`apps/dashboard/app/api/analyze/route.ts`](../../apps/dashboard/app/api/analyze/route.ts) for course allow-list slugs.

--- a/research/datasets/templates/post_ai_30.template.csv
+++ b/research/datasets/templates/post_ai_30.template.csv
@@ -1,0 +1,2 @@
+result_id,owner,repo,repo_url,course_id,team_name,commit_sha
+owner-repo-abc12345,example-org,example-repo,https://github.com/example-org/example-repo,CSE115A-Summer26,Team Alpha,abc123def456

--- a/research/datasets/templates/pre_ai_baseline.template.csv
+++ b/research/datasets/templates/pre_ai_baseline.template.csv
@@ -1,0 +1,2 @@
+owner,repo,url,term,notes
+example-org,example-repo-2021,https://github.com/example-org/example-repo-2021,2021-fall,Human-only baseline; replace with instructor rows

--- a/research/fixtures/cursor/README.md
+++ b/research/fixtures/cursor/README.md
@@ -1,0 +1,7 @@
+# Cursor log fixtures (SIP Sprint 1 — Objective 4)
+
+Place **sanitized** Cursor JSONL samples here for parser development and tests.
+
+Instructor delivers the kickoff sample at Sprint 1 kickoff (see [`../KICKOFF_CHECKLIST.md`](../KICKOFF_CHECKLIST.md)).
+
+Students copy or symlink samples into `agent_stats/` when working on story **SIP-1.4**. Document discovered schema in `agent_stats/docs/CURSOR_LOG_FORMAT.md` (on the `scottyUX/agent_stats` fork).

--- a/research/survey/README.md
+++ b/research/survey/README.md
@@ -1,0 +1,30 @@
+# Survey replication pipeline (SIP Sprint 1 — Objective 2)
+
+Reproduce paper statistics (Friedman, Pearson, Cronbach's α) for the new Qualtrics cohort.
+
+## Layout
+
+```
+research/survey/
+├── README.md                 # this file
+├── requirements.txt          # added by Student B in Sprint 1
+├── data/
+│   ├── raw/                  # gitignored — instructor Qualtrics export
+│   └── processed/            # gitignored — cleaned responses
+├── outputs/                  # gitignored — replication_report.md, tables
+├── clean_qualtrics.py
+├── stats_reliability.py
+├── stats_friedman.py
+├── stats_correlations.py
+└── run_all.sh                # one-command reproducibility
+```
+
+## Getting started
+
+1. Wait for instructor kickoff packet (see [`../KICKOFF_CHECKLIST.md`](../KICKOFF_CHECKLIST.md)).
+2. Place de-identified export in `data/raw/`.
+3. Follow story **SIP-1.2** on GitHub for task checklist.
+
+## Paper reference
+
+Target values and construct definitions: [`apps/dashboard/components/research/ResearchPaperBody.tsx`](../../apps/dashboard/components/research/ResearchPaperBody.tsx).


### PR DESCRIPTION
Adds research/ folder structure, kickoff checklist, CSV templates, and gitignore for Sprint 1 student work.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added README guides for research datasets, survey replication pipeline, and Cursor log fixtures.
  * Added sprint kickoff checklist for research deliverables.

* **Chores**
  * Added `.gitignore` to exclude research artifacts, data directories, and Python cache files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->