### PR TITLE
Document agent-stats clone setup for SIP students

### DIFF
--- a/research/AGENT_STATS_SETUP.md
+++ b/research/AGENT_STATS_SETUP.md
@@ -1,0 +1,49 @@
+# agent-stats setup (required for Sprint 1)
+
+**agent-stats is a separate GitHub repo.** It is **not** included inside `ts-repo-metrics` when you clone from GitHub. Every student must clone it into a folder named `agent_stats` next to the other project folders.
+
+## One-time setup
+
+From the root of your `ts-repo-metrics` clone:
+
+```bash
+git clone https://github.com/scottyUX/agent_stats.git agent_stats
+cd agent_stats
+git checkout a2a051d0991e
+cd ..
+```
+
+The checkout line pins everyone to the same version for Sprint 1 (commit message: *add --tokens and --messages flags*).
+
+## Verify it worked
+
+```bash
+test -f agent_stats/ai_usage_stats.py && echo "OK: agent_stats is ready"
+python3 agent_stats/ai_usage_stats.py --help
+```
+
+You should see help text, not "No such file."
+
+## Smoke test (SIP-1.1)
+
+```bash
+python3 agent_stats/ai_usage_stats.py \
+  --student "baseline@test.local" \
+  --csv /tmp/baseline_trace.csv
+```
+
+Post the first few lines of the CSV (or note that it is empty) in [Discussion #111](https://github.com/scottyUX/ts-repo-metrics/discussions/111).
+
+## Where to edit code (SIP-1.4)
+
+Open Pull Requests on **https://github.com/scottyUX/agent_stats**, not on `ts-repo-metrics`. Keep your local `agent_stats/` folder as a normal git clone of that repo.
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `agent_stats/` missing after cloning ts-repo-metrics only | Run the `git clone` command above |
+| `Permission denied` running the script | Use `python3 agent_stats/ai_usage_stats.py` instead of `./agent_stats/...` |
+| Wrong or old code | `cd agent_stats && git fetch scottyux && git checkout a2a051d0991e` |
+
+See also: [docs/AI_USAGE_LOGS.md](../docs/AI_USAGE_LOGS.md)

--- a/research/KICKOFF_CHECKLIST.md
+++ b/research/KICKOFF_CHECKLIST.md
@@ -35,6 +35,14 @@ Track instructor delivery in issue **SIP-1.0** (Kickoff packet).
 - [ ] Supabase: read-only credentials or export dump for Obj 3 audit (optional if lists are pre-verified)
 - [ ] Confirm students can run `npm test` and Python 3 locally
 
+## 6. agent-stats clone (all students — not in ts-repo-metrics repo)
+
+`agent_stats/` is **not** on the `ts-repo-metrics` GitHub repo. Students must clone it separately. Share this doc at kickoff: [`research/AGENT_STATS_SETUP.md`](AGENT_STATS_SETUP.md)
+
+- [ ] Walk through the clone commands in the first 10 minutes of kickoff
+- [ ] PM verifies every student has `agent_stats/ai_usage_stats.py` by EOD Day 2
+- [ ] Pinned commit for Sprint 1: `a2a051d0991e` on `scottyUX/agent_stats`
+
 ## Replication targets (Objective 2 reference)
 
 Paper statistics to reproduce are documented in [`apps/dashboard/components/research/ResearchPaperBody.tsx`](../apps/dashboard/components/research/ResearchPaperBody.tsx):

--- a/research/SPRINT_1_BOARD_SETUP.md
+++ b/research/SPRINT_1_BOARD_SETUP.md
@@ -14,6 +14,7 @@ Add these issues from `scottyUX/ts-repo-metrics`:
 | [#115](https://github.com/scottyUX/ts-repo-metrics/issues/115) | SIP-1.3 Dataset cohorts |
 | [#116](https://github.com/scottyUX/ts-repo-metrics/issues/116) | SIP-1.4 Cursor telemetry |
 | [#117](https://github.com/scottyUX/ts-repo-metrics/issues/117) | SIP-1.5 PM / Scrum |
+| [#119](https://github.com/scottyUX/ts-repo-metrics/issues/119) | SIP-1.6 Antigravity AI usage stats + dashboard prompt |
 
 **How:** Project 3 → **Add item** → search issue number or title.
 
@@ -48,8 +49,19 @@ Fill GitHub assignees on each issue:
 | #115 | Student C — Dataset | _TBD_ |
 | #116 | Student D — Cursor | _TBD_ |
 | #117 | Student E — PM | _TBD_ |
+| #119 | Student — Antigravity parser (agent_stats + dashboard) | _TBD_ |
 
 PM (#117) also supports #113 baseline verification.
+
+## Verify agent-stats clone (EOD Day 2)
+
+`agent_stats/` is **not** in the ts-repo-metrics GitHub repo. Every student must clone it separately. Share at kickoff: [research/AGENT_STATS_SETUP.md](AGENT_STATS_SETUP.md)
+
+PM checks each student has:
+
+```bash
+test -f agent_stats/ai_usage_stats.py && echo OK
+```
 
 ## Pin Discussion
 
@@ -60,5 +72,5 @@ Pin [Discussion #111 — Sprint 1 Architecture](https://github.com/scottyUX/ts-r
 ```bash
 gh auth refresh -s project
 gh project item-add 3 --owner scottyUX --url https://github.com/scottyUX/ts-repo-metrics/issues/113
-# repeat for 112–117
+# repeat for 112–117, 119
 ```

--- a/research/fixtures/cursor/README.md
+++ b/research/fixtures/cursor/README.md
@@ -4,4 +4,4 @@ Place **sanitized** Cursor JSONL samples here for parser development and tests.
 
 Instructor delivers the kickoff sample at Sprint 1 kickoff (see [`../KICKOFF_CHECKLIST.md`](../KICKOFF_CHECKLIST.md)).
 
-Students copy or symlink samples into `agent_stats/` when working on story **SIP-1.4**. Document discovered schema in `agent_stats/docs/CURSOR_LOG_FORMAT.md` (on the `scottyUX/agent_stats` fork).
+Students work in a local clone of [scottyUX/agent_stats](https://github.com/scottyUX/agent_stats) inside `agent_stats/`. If that folder is missing, follow [research/AGENT_STATS_SETUP.md](../../AGENT_STATS_SETUP.md) first.


### PR DESCRIPTION
Option 1: students clone scottyUX/agent_stats into agent_stats/ with pinned commit a2a051d0991e. Adds AGENT_STATS_SETUP.md and kickoff/PM checklist updates.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup and initialization guide for agent-stats with troubleshooting section
  * Updated project kickoff checklist with new configuration requirements and verification steps
  * Enhanced sprint board planning documentation with Day 2 verification checkpoints
  * Clarified setup instructions and repository structure across all project guidance materials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->