### PR TITLE
SIP-1.6.2: Update docs/AI_USAGE_LOGS.md & prompts on AI Usage tab with AI log paths

### DIFF
--- a/apps/dashboard/__tests__/aiUsagePromptTemplates.test.ts
+++ b/apps/dashboard/__tests__/aiUsagePromptTemplates.test.ts
@@ -4,6 +4,7 @@ import {
   AGENT_STATS_REPO_URL,
   AGENT_STATS_DESKTOP_DIR,
   AI_USAGE_DESKTOP_CSV_PATH,
+  AI_USAGE_DESKTOP_CSV_PATH_WIN,
   AI_USAGE_PROMPT_PLATFORMS,
   buildAiUsagePrompt,
   getAiUsagePromptPlatform,
@@ -32,11 +33,35 @@ describe("aiUsagePromptTemplates", () => {
     expect(prompt).toContain("--csv");
   });
 
-  it("uses the correct roots glob for each supported platform", () => {
+  it("includes the Mac roots glob and Windows roots glob for each platform", () => {
     for (const platform of AI_USAGE_PROMPT_PLATFORMS) {
       const prompt = buildAiUsagePrompt(platform.id);
       expect(getAiUsagePromptPlatform(platform.id).label).toBe(platform.label);
       expect(prompt).toContain(`--roots "${platform.rootsGlob}"`);
+      expect(prompt).toContain(`--roots "${platform.rootsGlobWindows}"`);
+      expect(prompt).toContain(AI_USAGE_DESKTOP_CSV_PATH_WIN);
+    }
+  });
+
+  it("includes Linux roots glob for Cursor (differs from Mac)", () => {
+    const prompt = buildAiUsagePrompt("cursor");
+    const cursorConfig = getAiUsagePromptPlatform("cursor");
+    expect(cursorConfig.rootsGlobLinux).toBeDefined();
+    expect(prompt).toContain(`--roots "${cursorConfig.rootsGlobLinux}"`);
+  });
+
+  it("includes coding_agent guidance for Cursor", () => {
+    const prompt = buildAiUsagePrompt("cursor");
+    expect(prompt).toContain("coding_agent = cursor");
+    expect(prompt).toContain("workspaceStorage");
+  });
+
+  it("groups Mac and Linux together for platforms where the path is the same", () => {
+    for (const platform of AI_USAGE_PROMPT_PLATFORMS) {
+      if (platform.id === "cursor") continue;
+      const prompt = buildAiUsagePrompt(platform.id);
+      expect(prompt).toContain("Mac / Linux:");
+      expect(prompt).not.toContain("Mac:\n");
     }
   });
 });

--- a/apps/dashboard/lib/aiUsagePromptTemplates.ts
+++ b/apps/dashboard/lib/aiUsagePromptTemplates.ts
@@ -4,43 +4,59 @@ export const AGENT_STATS_REPO_URL = "https://github.com/scottyUX/agent_stats";
 export const AGENT_STATS_BRANCH = "main";
 export const AGENT_STATS_DESKTOP_DIR = "$HOME/Desktop/agent_stats";
 export const AI_USAGE_DESKTOP_CSV_PATH = "$HOME/Desktop/ai_usage_trace.csv";
+export const AI_USAGE_DESKTOP_CSV_PATH_WIN =
+  "$env:USERPROFILE\\Desktop\\ai_usage_trace.csv";
 
 interface AiUsagePromptPlatformConfig {
   id: AiUsagePromptPlatform;
   label: string;
   shortLabel: string;
+  /** Mac log path glob (also used for Linux when rootsGlobLinux is not set). */
   rootsGlob: string;
+  /** Linux log path glob. Falls back to rootsGlob when not set. */
+  rootsGlobLinux?: string;
+  /** Windows PowerShell log path glob. */
+  rootsGlobWindows: string;
   codingAgent?: string;
 }
 
-export const AI_USAGE_PROMPT_PLATFORMS: readonly AiUsagePromptPlatformConfig[] = [
-  {
-    id: "claude",
-    label: "Claude Code",
-    shortLabel: "Claude",
-    rootsGlob: "$HOME/.claude/projects/**/*.jsonl",
-  },
-  {
-    id: "codex",
-    label: "Codex",
-    shortLabel: "Codex",
-    rootsGlob: "$HOME/.codex/sessions/**/rollout-*.jsonl",
-  },
-  {
-    id: "gemini",
-    label: "Gemini",
-    shortLabel: "Gemini",
-    rootsGlob: "$HOME/.gemini/tmp/**/session-*.json",
-  },
-  {
-    id: "cursor",
-    label: "Cursor",
-    shortLabel: "Cursor",
-    rootsGlob:
-      "$HOME/Library/Application Support/Cursor/User/workspaceStorage/**/*.jsonl",
-    codingAgent: "cursor",
-  },
-] as const;
+export const AI_USAGE_PROMPT_PLATFORMS: readonly AiUsagePromptPlatformConfig[] =
+  [
+    {
+      id: "claude",
+      label: "Claude Code",
+      shortLabel: "Claude",
+      rootsGlob: "$HOME/.claude/projects/**/*.jsonl",
+      rootsGlobWindows: "$env:USERPROFILE\\.claude\\projects\\**\\*.jsonl",
+    },
+    {
+      id: "codex",
+      label: "Codex",
+      shortLabel: "Codex",
+      rootsGlob: "$HOME/.codex/sessions/**/rollout-*.jsonl",
+      rootsGlobWindows:
+        "$env:USERPROFILE\\.codex\\sessions\\**\\rollout-*.jsonl",
+    },
+    {
+      id: "gemini",
+      label: "Gemini",
+      shortLabel: "Gemini",
+      rootsGlob: "$HOME/.gemini/tmp/**/session-*.json",
+      rootsGlobWindows: "$env:USERPROFILE\\.gemini\\tmp\\**\\session-*.json",
+    },
+    {
+      id: "cursor",
+      label: "Cursor",
+      shortLabel: "Cursor",
+      rootsGlob:
+        "$HOME/Library/Application Support/Cursor/User/workspaceStorage/**/*.jsonl",
+      rootsGlobLinux:
+        "$HOME/.config/Cursor/User/workspaceStorage/**/*.jsonl",
+      rootsGlobWindows:
+        "$env:APPDATA\\Cursor\\User\\workspaceStorage\\**\\*.jsonl",
+      codingAgent: "cursor",
+    },
+  ] as const;
 
 export function getAiUsagePromptPlatform(
   platform: AiUsagePromptPlatform,
@@ -54,6 +70,9 @@ export function getAiUsagePromptPlatform(
 
 export function buildAiUsagePrompt(platform: AiUsagePromptPlatform): string {
   const config = getAiUsagePromptPlatform(platform);
+  const linuxGlob = config.rootsGlobLinux ?? config.rootsGlob;
+  const macLinuxSame = linuxGlob === config.rootsGlob;
+
   const platformGuidance = config.codingAgent
     ? [
         `The exported CSV must use coding_agent = ${config.codingAgent}.`,
@@ -61,6 +80,39 @@ export function buildAiUsagePrompt(platform: AiUsagePromptPlatform): string {
         "",
       ]
     : [];
+
+  const step3Lines = macLinuxSame
+    ? [
+        "3. Run the command for your OS:",
+        "   Mac / Linux:",
+        `     ./ai_usage_stats.py --roots "${config.rootsGlob}" --filter "<INFERRED_OR_CONFIRMED_FILTER>" --tokens --messages --csv "${AI_USAGE_DESKTOP_CSV_PATH}"`,
+        "   Windows (PowerShell):",
+        `     python ai_usage_stats.py --roots "${config.rootsGlobWindows}" --filter "<INFERRED_OR_CONFIRMED_FILTER>" --tokens --messages --csv "${AI_USAGE_DESKTOP_CSV_PATH_WIN}"`,
+      ]
+    : [
+        "3. Run the command for your OS:",
+        "   Mac:",
+        `     ./ai_usage_stats.py --roots "${config.rootsGlob}" --filter "<INFERRED_OR_CONFIRMED_FILTER>" --tokens --messages --csv "${AI_USAGE_DESKTOP_CSV_PATH}"`,
+        "   Linux:",
+        `     ./ai_usage_stats.py --roots "${linuxGlob}" --filter "<INFERRED_OR_CONFIRMED_FILTER>" --tokens --messages --csv "${AI_USAGE_DESKTOP_CSV_PATH}"`,
+        "   Windows (PowerShell):",
+        `     python ai_usage_stats.py --roots "${config.rootsGlobWindows}" --filter "<INFERRED_OR_CONFIRMED_FILTER>" --tokens --messages --csv "${AI_USAGE_DESKTOP_CSV_PATH_WIN}"`,
+      ];
+
+  const step4Lines = macLinuxSame
+    ? [
+        "4. If the script is not executable or Python is not resolved on Mac / Linux, retry with:",
+        `   python3 ai_usage_stats.py --roots "${config.rootsGlob}" --filter "<INFERRED_OR_CONFIRMED_FILTER>" --tokens --messages --csv "${AI_USAGE_DESKTOP_CSV_PATH}"`,
+        "   Windows (PowerShell): the step 3 command already uses python — no retry needed.",
+      ]
+    : [
+        "4. If the script is not executable or Python is not resolved on Mac or Linux, retry with:",
+        "   Mac:",
+        `     python3 ai_usage_stats.py --roots "${config.rootsGlob}" --filter "<INFERRED_OR_CONFIRMED_FILTER>" --tokens --messages --csv "${AI_USAGE_DESKTOP_CSV_PATH}"`,
+        "   Linux:",
+        `     python3 ai_usage_stats.py --roots "${linuxGlob}" --filter "<INFERRED_OR_CONFIRMED_FILTER>" --tokens --messages --csv "${AI_USAGE_DESKTOP_CSV_PATH}"`,
+        "   Windows (PowerShell): the step 3 command already uses python — no retry needed.",
+      ];
 
   return [
     "Use your terminal tools to help me generate my AI usage CSV. Do not modify my project files.",
@@ -81,15 +133,13 @@ export function buildAiUsagePrompt(platform: AiUsagePromptPlatform): string {
     "",
     `2. Change into "${AGENT_STATS_DESKTOP_DIR}".`,
     "",
-    "3. Prefer the executable script and run:",
-    `   ./ai_usage_stats.py --roots "${config.rootsGlob}" --filter "<INFERRED_OR_CONFIRMED_FILTER>" --tokens --messages --csv "${AI_USAGE_DESKTOP_CSV_PATH}"`,
+    ...step3Lines,
     "",
-    "4. If that fails because the script is not executable or Python is not resolved, retry with:",
-    `   python3 ai_usage_stats.py --roots "${config.rootsGlob}" --filter "<INFERRED_OR_CONFIRMED_FILTER>" --tokens --messages --csv "${AI_USAGE_DESKTOP_CSV_PATH}"`,
+    ...step4Lines,
     "",
     "5. When done, tell me only:",
     "   - success or failure",
-    `   - the exact file path of the CSV on my Desktop (${AI_USAGE_DESKTOP_CSV_PATH})`,
+    "   - the exact file path of the CSV on your Desktop",
     "",
     "If you need permission for shell or network commands, ask once and then continue.",
   ].join("\n");

--- a/docs/AI_USAGE_LOGS.md
+++ b/docs/AI_USAGE_LOGS.md
@@ -6,7 +6,7 @@ analysis record so the metrics reload with the result page.
 
 The primary student workflow is now:
 
-1. choose `Claude Code`, `Codex`, or `Gemini` in the AI Usage tab
+1. choose `Claude Code`, `Codex`, `Gemini`, or `Cursor` in the AI Usage tab
 2. copy the generated prompt
 3. run it in that same coding-agent project so the agent can infer `--filter`
 4. upload the resulting CSV
@@ -84,7 +84,7 @@ This is separate from `POST /api/analyze`; it uses dedicated AI Usage persistenc
 
 1. Open a **results** view that includes the AI Usage tab (the page renders
    [`AIMaturityTab`](../apps/dashboard/components/results/rq/AIMaturityTab.tsx)).
-2. Choose the platform prompt for `Claude Code`, `Codex`, or `Gemini`.
+2. Choose the platform prompt for `Claude Code`, `Codex`, `Gemini`, or `Cursor`.
 3. Copy the prompt and run it in the same coding-agent project.
 4. Upload the generated CSV on the AI Usage tab.
 5. Review any warnings about missing optional columns.
@@ -101,3 +101,131 @@ This is separate from `POST /api/analyze`; it uses dedicated AI Usage persistenc
 - There is **no demo data** in the current tab.
 - The tab no longer accepts **JSON** or **JSONL** uploads.
 - The old **AUM score** and stage-aware display are no longer part of the live student UI.
+
+## Cursor
+
+Cursor stores conversation logs as JSONL files in its workspace storage folder. The path differs by OS:
+
+| OS | Default log path |
+|----|-----------------|
+| Mac | `~/Library/Application Support/Cursor/User/workspaceStorage/` |
+| Linux | `~/.config/Cursor/User/workspaceStorage/` |
+| Windows | `%APPDATA%\Cursor\User\workspaceStorage\` |
+
+The `agent_stats` export command for Cursor logs:
+
+**Mac:**
+```bash
+./ai_usage_stats.py \
+  --roots "$HOME/Library/Application Support/Cursor/User/workspaceStorage/**/*.jsonl" \
+  --filter your-repo-slug \
+  --tokens --messages \
+  --csv "$HOME/Desktop/ai_usage_trace.csv"
+```
+
+**Linux:**
+```bash
+./ai_usage_stats.py \
+  --roots "$HOME/.config/Cursor/User/workspaceStorage/**/*.jsonl" \
+  --filter your-repo-slug \
+  --tokens --messages \
+  --csv "$HOME/Desktop/ai_usage_trace.csv"
+```
+
+**Windows (PowerShell):**
+```powershell
+python ai_usage_stats.py `
+  --roots "$env:APPDATA\Cursor\User\workspaceStorage\**\*.jsonl" `
+  --filter your-repo-slug `
+  --tokens --messages `
+  --csv "$env:USERPROFILE\Desktop\ai_usage_trace.csv"
+```
+
+> The exported CSV must set `coding_agent = cursor`.
+
+## Claude Code
+
+Claude Code stores conversation logs as JSONL files under `~/.claude/projects/`. The path is the same on Mac and Linux; Windows differs:
+
+| OS | Default log path |
+|----|-----------------|
+| Mac / Linux | `~/.claude/projects/` |
+| Windows | `%USERPROFILE%\.claude\projects\` |
+
+The `agent_stats` export command for Claude Code logs:
+
+**Mac / Linux:**
+```bash
+./ai_usage_stats.py \
+  --roots "$HOME/.claude/projects/**/*.jsonl" \
+  --filter your-repo-slug \
+  --tokens --messages \
+  --csv "$HOME/Desktop/ai_usage_trace.csv"
+```
+
+**Windows (PowerShell):**
+```powershell
+python ai_usage_stats.py `
+  --roots "$env:USERPROFILE\.claude\projects\**\*.jsonl" `
+  --filter your-repo-slug `
+  --tokens --messages `
+  --csv "$env:USERPROFILE\Desktop\ai_usage_trace.csv"
+```
+
+## Codex
+
+Codex stores conversation logs as JSONL files under `~/.codex/sessions/`. The path is the same on Mac and Linux; Windows differs:
+
+| OS | Default log path |
+|----|-----------------|
+| Mac / Linux | `~/.codex/sessions/` |
+| Windows | `%USERPROFILE%\.codex\sessions\` |
+
+The `agent_stats` export command for Codex logs:
+
+**Mac / Linux:**
+```bash
+./ai_usage_stats.py \
+  --roots "$HOME/.codex/sessions/**/rollout-*.jsonl" \
+  --filter your-repo-slug \
+  --tokens --messages \
+  --csv "$HOME/Desktop/ai_usage_trace.csv"
+```
+
+**Windows (PowerShell):**
+```powershell
+python ai_usage_stats.py `
+  --roots "$env:USERPROFILE\.codex\sessions\**\rollout-*.jsonl" `
+  --filter your-repo-slug `
+  --tokens --messages `
+  --csv "$env:USERPROFILE\Desktop\ai_usage_trace.csv"
+```
+
+## Gemini
+
+Gemini stores conversation logs as JSON files under `~/.gemini/tmp/`. The path is the same on Mac and Linux; Windows differs:
+
+| OS | Default log path |
+|----|-----------------|
+| Mac / Linux | `~/.gemini/tmp/` |
+| Windows | `%USERPROFILE%\.gemini\tmp\` |
+
+The `agent_stats` export command for Gemini logs:
+
+**Mac / Linux:**
+```bash
+./ai_usage_stats.py \
+  --roots "$HOME/.gemini/tmp/**/session-*.json" \
+  --filter your-repo-slug \
+  --tokens --messages \
+  --csv "$HOME/Desktop/ai_usage_trace.csv"
+```
+
+**Windows (PowerShell):**
+```powershell
+python ai_usage_stats.py `
+  --roots "$env:USERPROFILE\.gemini\tmp\**\session-*.json" `
+  --filter your-repo-slug `
+  --tokens --messages `
+  --csv "$env:USERPROFILE\Desktop\ai_usage_trace.csv"
+```


### PR DESCRIPTION
## Summary

- Adds per-platform sections to `docs/AI_USAGE_LOGS.md` for all four platforms (Cursor, Claude Code, Codex, Gemini), each with a path table and `agent_stats` export command for Mac, Linux, and Windows
- Updates `aiUsagePromptTemplates.ts` so the prompt copied from the AI Usage dashboard tab now emits OS-specific command variants (Mac/Linux grouped where paths are identical; Cursor gets three separate blocks since its Mac path differs from Linux)
- Adds `rootsGlobLinux` and `rootsGlobWindows` fields to the platform config interface and introduces `AI_USAGE_DESKTOP_CSV_PATH_WIN` constant
- Updates two existing lines in `AI_USAGE_LOGS.md` that listed only three platforms to include Cursor
- Updates `aiUsagePromptTemplates.test.ts` to assert Mac, Linux, and Windows paths are present in each generated prompt

Closes #127. Part of #119.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified — zero errors)
- [ ] Linter passes on changed files (verified — no errors)
- [ ] Start dashboard (`npm run dev` from `apps/dashboard`), open a results page with the AI Usage tab, select each of the four platforms and confirm the copied prompt contains the correct OS-labelled command blocks
- [ ] Verify `docs/AI_USAGE_LOGS.md` renders correctly on GitHub with tables and code blocks for all four platforms

Made with [Cursor](https://cursor.com)