### PR TITLE
SIP-1.6.4: Add Cursor logo and tool list to AI Usage tab

### DIFF
--- a/apps/dashboard/components/results/rq/AIMaturityTab.tsx
+++ b/apps/dashboard/components/results/rq/AIMaturityTab.tsx
@@ -395,6 +395,39 @@ function AgentStatsExportInsight() {
                     </a>
                   </Button>
                 </div>
+
+                {platform.tools && (
+                  <div className="space-y-2 border-t border-border/40 pt-3">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      Common tool names in your Cursor CSV:
+                    </p>
+                    {(["exploration", "generation", "verification"] as const).map((bucket) => {
+                      const bucketTools = platform.tools!.filter((t) => t.bucket === bucket);
+                      if (bucketTools.length === 0) return null;
+                      const label =
+                        bucket === "exploration"
+                          ? "Exploration"
+                          : bucket === "generation"
+                          ? "Generation"
+                          : "Verification";
+                      return (
+                        <div key={bucket} className="flex flex-wrap items-center gap-1.5">
+                          <span className="w-20 shrink-0 text-xs text-muted-foreground">
+                            {label}
+                          </span>
+                          {bucketTools.map((tool) => (
+                            <code
+                              key={tool.name}
+                              className="rounded bg-muted px-1.5 py-0.5 text-xs text-foreground"
+                            >
+                              {tool.name}
+                            </code>
+                          ))}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             </TabsContent>
           );

--- a/apps/dashboard/components/results/rq/AiUsagePlatformLogo.tsx
+++ b/apps/dashboard/components/results/rq/AiUsagePlatformLogo.tsx
@@ -93,6 +93,21 @@ export function AiUsagePlatformLogo({
     );
   }
 
+  if (platform === "cursor") {
+    return (
+      <svg
+        viewBox="0 0 24 24"
+        className={cn("size-4 shrink-0", className)}
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          d="M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23"
+        />
+      </svg>
+    );
+  }
+
   return (
     <svg
       viewBox="0 0 24 24"

--- a/apps/dashboard/lib/aiUsagePromptTemplates.ts
+++ b/apps/dashboard/lib/aiUsagePromptTemplates.ts
@@ -18,6 +18,10 @@ interface AiUsagePromptPlatformConfig {
   /** Windows PowerShell log path glob. */
   rootsGlobWindows: string;
   codingAgent?: string;
+  tools?: ReadonlyArray<{
+    name: string;
+    bucket: "exploration" | "generation" | "verification";
+  }>;
 }
 
 export const AI_USAGE_PROMPT_PLATFORMS: readonly AiUsagePromptPlatformConfig[] =
@@ -55,6 +59,19 @@ export const AI_USAGE_PROMPT_PLATFORMS: readonly AiUsagePromptPlatformConfig[] =
       rootsGlobWindows:
         "$env:APPDATA\\Cursor\\User\\workspaceStorage\\**\\*.jsonl",
       codingAgent: "cursor",
+      tools: [
+        { name: "Read",           bucket: "exploration"  },
+        { name: "Glob",           bucket: "exploration"  },
+        { name: "Grep",           bucket: "exploration"  },
+        { name: "SemanticSearch", bucket: "exploration"  },
+        { name: "WebSearch",      bucket: "exploration"  },
+        { name: "WebFetch",       bucket: "exploration"  },
+        { name: "Write",          bucket: "generation"   },
+        { name: "StrReplace",     bucket: "generation"   },
+        { name: "EditNotebook",   bucket: "generation"   },
+        { name: "Shell",          bucket: "verification" },
+        { name: "Task",           bucket: "verification" },
+      ],
     },
   ] as const;
 


### PR DESCRIPTION
## Summary

- Adds the official Cursor SVG logo (sourced from simple-icons, `fill="currentColor"` for dark/light mode compatibility) to `AiUsagePlatformLogo.tsx` — Cursor previously fell through to the Codex/OpenAI fallback icon
- Adds an optional `tools` field to `AiUsagePromptPlatformConfig` in `aiUsagePromptTemplates.ts`, populated for Cursor with 11 entries grouped by behavioral bucket (exploration / generation / verification)
- Renders a tool-name reference section below the copy buttons in the Cursor tab panel in `AIMaturityTab.tsx`, so students can cross-reference `tool_name` values in their uploaded CSV

Closes #129. Part of #119.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified — zero errors)
- [ ] Linter passes on all three changed files (verified — no errors)
- [ ] Start dashboard (`npm run dev` from `apps/dashboard`), open the AI Usage tab, confirm the Cursor tab shows the hexagonal Cursor logo in the tab selector (not the Codex gear icon)
- [ ] Confirm the tool reference list appears below the copy buttons in the Cursor tab, with Exploration / Generation / Verification rows and correct tool name badges
- [ ] Confirm Claude Code, Codex, and Gemini tabs are unchanged (no tool list, correct logos)

Made with [Cursor](https://cursor.com)