### PR TITLE
SIP-1.6.6: Fix duplicate React keys in activity heatmap weekday header

### DIFF
--- a/apps/dashboard/components/results/rq/AIMaturityTab.tsx
+++ b/apps/dashboard/components/results/rq/AIMaturityTab.tsx
@@ -860,7 +860,7 @@ export function AIMaturityTab({ resultId }: { resultId: string }) {
                     </div>
                     {WEEKDAY_LETTERS.map((letter, dayIndex) => (
                       <div
-                        key={letter}
+                        key={dayIndex}
                         className={cn("flex items-center", HEATMAP_GAP)}
                       >
                         <div className={cn(HEATMAP_LABEL_COL, "select-none")}>


### PR DESCRIPTION
Closes #156.

Found during SIP-1.6.5 smoke testing. The `WEEKDAY_LETTERS` array in `AIMaturityTab.tsx` used `key={letter}` to render the activity heatmap weekday header, but `"T"` (Tuesday/Thursday) and `"S"` (Saturday/Sunday) each appear twice, causing duplicate React key warnings in the console. Fixes by switching to `key={dayIndex}` so each column has a unique key.

## Change

`AIMaturityTab.tsx` line 863: `key={letter}` → `key={dayIndex}`

Made with [Cursor](https://cursor.com)