### PR TITLE
SIP-1.6.7: Fix Cursor prompt log path to agent-transcripts

### DIFF
--- a/apps/dashboard/__tests__/aiUsagePromptTemplates.test.ts
+++ b/apps/dashboard/__tests__/aiUsagePromptTemplates.test.ts
@@ -43,22 +43,22 @@ describe("aiUsagePromptTemplates", () => {
     }
   });
 
-  it("includes Linux roots glob for Cursor (differs from Mac)", () => {
-    const prompt = buildAiUsagePrompt("cursor");
+  it("uses the same roots glob for Mac and Linux for Cursor (agent-transcripts path)", () => {
     const cursorConfig = getAiUsagePromptPlatform("cursor");
-    expect(cursorConfig.rootsGlobLinux).toBeDefined();
-    expect(prompt).toContain(`--roots "${cursorConfig.rootsGlobLinux}"`);
+    expect(cursorConfig.rootsGlobLinux).toBeUndefined();
+    expect(cursorConfig.rootsGlob).toContain(".cursor/projects");
+    expect(cursorConfig.rootsGlob).toContain("agent-transcripts");
   });
 
   it("includes coding_agent guidance for Cursor", () => {
     const prompt = buildAiUsagePrompt("cursor");
-    expect(prompt).toContain("coding_agent = cursor");
-    expect(prompt).toContain("workspaceStorage");
+    expect(prompt).toContain(".cursor/projects");
+    expect(prompt).toContain("agent-transcripts");
+    expect(prompt).toContain("Cursor logs are JSONL files");
   });
 
-  it("groups Mac and Linux together for platforms where the path is the same", () => {
+  it("groups Mac and Linux together for all platforms including Cursor", () => {
     for (const platform of AI_USAGE_PROMPT_PLATFORMS) {
-      if (platform.id === "cursor") continue;
       const prompt = buildAiUsagePrompt(platform.id);
       expect(prompt).toContain("Mac / Linux:");
       expect(prompt).not.toContain("Mac:\n");

--- a/apps/dashboard/lib/aiUsagePromptTemplates.ts
+++ b/apps/dashboard/lib/aiUsagePromptTemplates.ts
@@ -53,11 +53,9 @@ export const AI_USAGE_PROMPT_PLATFORMS: readonly AiUsagePromptPlatformConfig[] =
       label: "Cursor",
       shortLabel: "Cursor",
       rootsGlob:
-        "$HOME/Library/Application Support/Cursor/User/workspaceStorage/**/*.jsonl",
-      rootsGlobLinux:
-        "$HOME/.config/Cursor/User/workspaceStorage/**/*.jsonl",
+        "$HOME/.cursor/projects/*/agent-transcripts/*/*.jsonl",
       rootsGlobWindows:
-        "$env:APPDATA\\Cursor\\User\\workspaceStorage\\**\\*.jsonl",
+        "$env:USERPROFILE\\.cursor\\projects\\*\\agent-transcripts\\*\\*.jsonl",
       codingAgent: "cursor",
       tools: [
         { name: "Read",           bucket: "exploration"  },
@@ -92,7 +90,6 @@ export function buildAiUsagePrompt(platform: AiUsagePromptPlatform): string {
 
   const platformGuidance = config.codingAgent
     ? [
-        `The exported CSV must use coding_agent = ${config.codingAgent}.`,
         "Cursor logs are JSONL files under the --roots path below.",
         "",
       ]


### PR DESCRIPTION
Closes #171.

Found during SIP-1.6.5 end-to-end testing. The Cursor prompt pointed to `workspaceStorage/**/*.jsonl` but Cursor stores agent conversation logs at `~/.cursor/projects/*/agent-transcripts/*/*.jsonl`. Running `agent_stats` with the old path returned 0 files; with the corrected path it found 5 sessions, 172 prompts, and 429 tool calls.

## Changes

- Update `rootsGlob` for Cursor in `aiUsagePromptTemplates.ts`:
  `$HOME/Library/Application Support/Cursor/User/workspaceStorage/**/*.jsonl`
  → `$HOME/.cursor/projects/*/agent-transcripts/*/*.jsonl`
- Update `rootsGlobWindows` to match (`%USERPROFILE%\.cursor\projects\*\agent-transcripts\*\*.jsonl`)
- Remove `rootsGlobLinux` — Mac and Linux now share the same path, so the prompt shows "Mac / Linux:" instead of separate sections
- Remove the `coding_agent = cursor` instruction from the generated prompt — the CSV actually comes out as `claude_code` until `agent_stats` is updated to classify these files as Cursor
- Update `aiUsagePromptTemplates.test.ts` to assert the new path and remove the workspaceStorage/Linux-specific assertions

## Verification

Ran `agent_stats` manually with the corrected path and confirmed CSV generation succeeds with real data.

Made with [Cursor](https://cursor.com)