### PR TITLE
chore: sync root lockfile with engine tree-sitter deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -793,9 +793,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -813,9 +810,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -833,9 +827,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -853,9 +844,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -873,9 +861,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -893,9 +878,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2121,9 +2103,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2145,9 +2124,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2169,9 +2145,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2193,9 +2166,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3030,6 +3000,25 @@
         }
       }
     },
+    "node_modules/tree-sitter-python": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.23.6.tgz",
+      "integrity": "sha512-yIM9z0oxKIxT7bAtPOhgoVl6gTXlmlIhue7liFT4oBPF/lha7Ha4dQBS82Av6hMMRZoVnFJI8M6mL+SwWoLD3A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tree-sitter-typescript": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
@@ -3373,6 +3362,8 @@
         "jscpd": "^4.0.8",
         "simple-git": "^3.31.1",
         "tree-sitter": "^0.21.1",
+        "tree-sitter-javascript": "^0.23.1",
+        "tree-sitter-python": "^0.23.6",
         "tree-sitter-typescript": "^0.23.2"
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary
- Sync root `package-lock.json` with `packages/engine` dependencies (`tree-sitter-python`, `tree-sitter-javascript`)
- Fixes `npm ci` failure in CI (`Missing: tree-sitter-python@0.23.6 from lock file`)

## Test plan
- [ ] CI `npm ci` step passes
- [ ] `npm test` passes


Made with [Cursor](https://cursor.com)