### PR TITLE
Fix AI usage CSV save when result_id does not exact-match (#201)

### DIFF
--- a/apps/dashboard/__tests__/aiUsageRoutes.test.ts
+++ b/apps/dashboard/__tests__/aiUsageRoutes.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getUser = vi.fn();
+const resolveAnalysisRow = vi.fn();
 
 // Table-aware Supabase mock — each call to from() returns a chainable object
 // whose terminal promise resolves to whatever tableResults[table] holds.
@@ -38,6 +39,11 @@ vi.mock("@/lib/analyzeConstants", () => ({
   ANALYZE_SIGN_IN_REQUIRED_MESSAGE: "Please sign in.",
 }));
 
+vi.mock("@/lib/resolveAnalysisRow", () => ({
+  resolveAnalysisRow: (...args: unknown[]) => resolveAnalysisRow(...args),
+}));
+
+const CANONICAL_ID = "owner-repo-abc123456789";
 const CSV =
   "timestamp,event_type,session_id,tool_name\n2026-05-20T10:00:00.000Z,user_prompt,s1,\n";
 
@@ -105,9 +111,14 @@ describe("ai usage routes — Supabase mode", () => {
     vi.resetModules();
     getUser.mockReset();
     fromFn.mockClear();
+    resolveAnalysisRow.mockReset();
     Object.keys(tableResults).forEach((k) => delete tableResults[k]);
 
     getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    resolveAnalysisRow.mockResolvedValue({
+      ok: true,
+      resultId: CANONICAL_ID,
+    });
 
     const { isDevReportMemoryFallback, isSupabaseConfigured } = await import(
       "@/lib/supabase/server"
@@ -116,8 +127,7 @@ describe("ai usage routes — Supabase mode", () => {
     vi.mocked(isSupabaseConfigured).mockReturnValue(true);
   });
 
-  it("upserts into ai_usage_csvs and returns 200", async () => {
-    tableResults["analyses"] = { data: { result_id: "owner-repo-abc" }, error: null };
+  it("upserts into ai_usage_csvs and returns canonical resultId", async () => {
     tableResults["ai_usage_csvs"] = { error: null };
 
     const { POST } = await import("../app/api/ai-usage/route");
@@ -125,20 +135,25 @@ describe("ai usage routes — Supabase mode", () => {
     const res = await POST(
       new NextRequest("http://localhost/api/ai-usage", {
         method: "POST",
-        body: JSON.stringify({ resultId: "owner-repo-abc", csvText: CSV }),
+        body: JSON.stringify({
+          resultId: "owner-repo-abc12345",
+          csvText: CSV,
+        }),
         headers: { "Content-Type": "application/json" },
       }),
     );
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toMatchObject({ resultId: "owner-repo-abc" });
+    await expect(res.json()).resolves.toMatchObject({
+      resultId: CANONICAL_ID,
+    });
 
-    // Must write to ai_usage_csvs (the per-user table), not via an UPDATE on analyses
     const tables = fromFn.mock.calls.map(([table]: [string]) => table);
     expect(tables).toContain("ai_usage_csvs");
+    expect(resolveAnalysisRow).toHaveBeenCalled();
   });
 
   it("returns 404 when analysis does not exist", async () => {
-    tableResults["analyses"] = { data: null, error: { message: "not found", code: "PGRST116" } };
+    resolveAnalysisRow.mockResolvedValue({ ok: false, code: "not_found" });
 
     const { POST } = await import("../app/api/ai-usage/route");
 
@@ -149,10 +164,23 @@ describe("ai usage routes — Supabase mode", () => {
         headers: { "Content-Type": "application/json" },
       }),
     );
-    // No analysis row → POST succeeds (FK will reject at DB level); or we still get 200 because
-    // the route no longer pre-checks existence and relies on the FK. Either way, no 403/forbidden.
-    // The important thing: no user_id cross-contamination.
-    expect([200, 404, 500]).toContain(res.status);
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "Analysis not found for this result.",
+      code: "not_found",
+    });
+  });
+
+  it("GET returns 404 when analysis cannot be resolved", async () => {
+    resolveAnalysisRow.mockResolvedValue({ ok: false, code: "not_found" });
+
+    const { GET } = await import("../app/api/results/[id]/ai-usage/route");
+
+    const res = await GET(
+      new NextRequest("http://localhost/api/results/owner-repo-abc/ai-usage"),
+      { params: Promise.resolve({ id: "owner-repo-abc" }) },
+    );
+    expect(res.status).toBe(404);
   });
 
   it("GET returns 404 when no row for this user in ai_usage_csvs", async () => {
@@ -178,7 +206,7 @@ describe("ai usage routes — Supabase mode", () => {
     );
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({
-      resultId: "owner-repo-abc",
+      resultId: CANONICAL_ID,
       csvText: CSV,
     });
   });

--- a/apps/dashboard/__tests__/resolveAnalysisRow.test.ts
+++ b/apps/dashboard/__tests__/resolveAnalysisRow.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ANALYSIS_ROW_MAX_RETRIES,
+  ANALYSIS_ROW_RETRY_DELAY_MS,
+  MIN_PARTIAL_RESULT_ID_LENGTH,
+  resolveAnalysisRow,
+} from "../lib/resolveAnalysisRow";
+
+function makeSupabaseMock(handlers: {
+  exact?: { data: { result_id: string } | null; error?: unknown };
+  prefix?: { data: { result_id: string } | null; error?: unknown };
+}) {
+  const eq = vi.fn(() => ({
+    maybeSingle: vi.fn(async () => handlers.exact ?? { data: null, error: null }),
+  }));
+  const like = vi.fn(() => ({
+    order: vi.fn(() => ({
+      limit: vi.fn(() => ({
+        maybeSingle: vi.fn(
+          async () => handlers.prefix ?? { data: null, error: null },
+        ),
+      })),
+    })),
+  }));
+  const select = vi.fn(() => ({ eq, like }));
+  const from = vi.fn(() => ({ select }));
+  return { from, eq, like, select };
+}
+
+describe("resolveAnalysisRow", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns exact match on first attempt", async () => {
+    const sb = makeSupabaseMock({
+      exact: { data: { result_id: "owner-repo-abc123456789" } },
+    });
+
+    const result = await resolveAnalysisRow(
+      "owner-repo-abc123456789",
+      sb as never,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      resultId: "owner-repo-abc123456789",
+    });
+    expect(sb.eq).toHaveBeenCalledWith("result_id", "owner-repo-abc123456789");
+    expect(sb.like).not.toHaveBeenCalled();
+  });
+
+  it("falls back to prefix match when exact match fails", async () => {
+    const prefixId = "owner-repo-abc123456789";
+    const shortPrefix = prefixId.slice(0, MIN_PARTIAL_RESULT_ID_LENGTH);
+
+    const sb = makeSupabaseMock({
+      exact: { data: null, error: null },
+      prefix: { data: { result_id: prefixId } },
+    });
+
+    const promise = resolveAnalysisRow(shortPrefix, sb as never);
+
+    for (let i = 0; i < ANALYSIS_ROW_MAX_RETRIES - 1; i++) {
+      await vi.advanceTimersByTimeAsync(ANALYSIS_ROW_RETRY_DELAY_MS * (i + 1));
+    }
+    const result = await promise;
+
+    expect(result).toEqual({ ok: true, resultId: prefixId });
+    expect(sb.like).toHaveBeenCalledWith("result_id", `${shortPrefix}%`);
+  });
+
+  it("skips prefix match for short ids", async () => {
+    const sb = makeSupabaseMock({
+      exact: { data: null, error: null },
+    });
+
+    const promise = resolveAnalysisRow("short-id", sb as never);
+    for (let i = 0; i < ANALYSIS_ROW_MAX_RETRIES; i++) {
+      await vi.advanceTimersByTimeAsync(ANALYSIS_ROW_RETRY_DELAY_MS * (i + 1));
+    }
+    const result = await promise;
+
+    expect(result).toEqual({ ok: false, code: "not_found" });
+    expect(sb.like).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found when no row matches", async () => {
+    const sb = makeSupabaseMock({
+      exact: { data: null, error: null },
+      prefix: { data: null, error: null },
+    });
+
+    const longId = "owner-repo-abc123456789";
+    const promise = resolveAnalysisRow(longId, sb as never);
+    for (let i = 0; i < ANALYSIS_ROW_MAX_RETRIES; i++) {
+      await vi.advanceTimersByTimeAsync(ANALYSIS_ROW_RETRY_DELAY_MS * (i + 1));
+    }
+    const result = await promise;
+
+    expect(result).toEqual({ ok: false, code: "not_found" });
+  });
+
+  it("returns not_found for empty id", async () => {
+    const sb = makeSupabaseMock({});
+    const result = await resolveAnalysisRow("  ", sb as never);
+    expect(result).toEqual({ ok: false, code: "not_found" });
+    expect(sb.from).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dashboard/app/api/ai-usage/route.ts
+++ b/apps/dashboard/app/api/ai-usage/route.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/supabase/server-user";
 import { ANALYZE_SIGN_IN_REQUIRED_MESSAGE } from "@/lib/analyzeConstants";
 import { devStoreAiUsageCsv } from "@/lib/devAiUsageStore";
+import { resolveAnalysisRow } from "@/lib/resolveAnalysisRow";
 
 const AI_USAGE_MIGRATION_HINT =
   "Run supabase/migrations/20260702000000_ai_usage_csvs_per_user.sql in the Supabase SQL Editor.";
@@ -86,27 +87,24 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (isSupabaseConfigured()) {
-      // Verify the analysis exists and is readable by this user (RLS allows
-      // null-owner rows and own rows).
-      const { data: row, error: selectError } = await userSb
-        .from("analyses")
-        .select("result_id")
-        .eq("result_id", resultId)
-        .maybeSingle();
+    let savedResultId = resultId;
 
-      if (selectError || !row) {
+    if (isSupabaseConfigured()) {
+      const resolved = await resolveAnalysisRow(resultId, userSb);
+      if (!resolved.ok) {
         return NextResponse.json(
           { error: "Analysis not found for this result.", code: "not_found" },
           { status: 404 },
         );
       }
 
+      savedResultId = resolved.resultId;
+
       // Upsert into the per-user table. RLS enforces user_id = auth.uid().
       const { error: upsertError } = await userSb
         .from("ai_usage_csvs")
         .upsert(
-          { result_id: resultId, user_id: user.id, csv_text: csvText },
+          { result_id: savedResultId, user_id: user.id, csv_text: csvText },
           { onConflict: "result_id,user_id" },
         );
 
@@ -136,7 +134,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    return NextResponse.json({ resultId, csvText });
+    return NextResponse.json({ resultId: savedResultId, csvText });
   } catch (err) {
     console.error("[ai-usage]", err instanceof Error ? err.message : err);
     const message =

--- a/apps/dashboard/app/api/results/[id]/ai-usage/route.ts
+++ b/apps/dashboard/app/api/results/[id]/ai-usage/route.ts
@@ -14,6 +14,7 @@ import {
   isUserSupabaseConfigured,
 } from "@/lib/supabase/server-user";
 import { devGetAiUsageCsv } from "@/lib/devAiUsageStore";
+import { resolveAnalysisRow } from "@/lib/resolveAnalysisRow";
 
 export async function GET(
   _request: NextRequest,
@@ -44,16 +45,24 @@ export async function GET(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const resolved = await resolveAnalysisRow(resultId, userSb);
+  if (!resolved.ok) {
+    return NextResponse.json({ error: "AI usage not found" }, { status: 404 });
+  }
+
   // RLS on ai_usage_csvs enforces user_id = auth.uid(); no manual filter needed.
   const { data, error } = await userSb
     .from("ai_usage_csvs")
     .select("csv_text")
-    .eq("result_id", resultId)
+    .eq("result_id", resolved.resultId)
     .maybeSingle();
 
   if (error || !data?.csv_text) {
     return NextResponse.json({ error: "AI usage not found" }, { status: 404 });
   }
 
-  return NextResponse.json({ resultId, csvText: data.csv_text as string });
+  return NextResponse.json({
+    resultId: resolved.resultId,
+    csvText: data.csv_text as string,
+  });
 }

--- a/apps/dashboard/lib/resolveAnalysisRow.ts
+++ b/apps/dashboard/lib/resolveAnalysisRow.ts
@@ -1,0 +1,58 @@
+/**
+ * Resolve an analyses row by result_id with retry + prefix match (matches results API).
+ * Uses the caller's Supabase client (typically user RLS) — visibility is enforced by RLS.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const ANALYSIS_ROW_MAX_RETRIES = 3;
+export const ANALYSIS_ROW_RETRY_DELAY_MS = 500;
+export const MIN_PARTIAL_RESULT_ID_LENGTH = 20;
+
+export type ResolveAnalysisRowResult =
+  | { ok: true; resultId: string }
+  | { ok: false; code: "not_found" };
+
+export async function resolveAnalysisRow(
+  requestedId: string,
+  supabase: SupabaseClient,
+): Promise<ResolveAnalysisRowResult> {
+  const trimmedId = requestedId.trim();
+  if (!trimmedId) {
+    return { ok: false, code: "not_found" };
+  }
+
+  for (let attempt = 1; attempt <= ANALYSIS_ROW_MAX_RETRIES; attempt++) {
+    const { data, error } = await supabase
+      .from("analyses")
+      .select("result_id")
+      .eq("result_id", trimmedId)
+      .maybeSingle();
+
+    if (data?.result_id && !error) {
+      return { ok: true, resultId: data.result_id };
+    }
+
+    if (attempt < ANALYSIS_ROW_MAX_RETRIES) {
+      await new Promise((r) =>
+        setTimeout(r, ANALYSIS_ROW_RETRY_DELAY_MS * attempt),
+      );
+    }
+  }
+
+  if (trimmedId.length >= MIN_PARTIAL_RESULT_ID_LENGTH) {
+    const { data, error } = await supabase
+      .from("analyses")
+      .select("result_id")
+      .like("result_id", `${trimmedId}%`)
+      .order("analyzed_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (data?.result_id && !error) {
+      return { ok: true, resultId: data.result_id };
+    }
+  }
+
+  return { ok: false, code: "not_found" };
+}


### PR DESCRIPTION
## Summary
- Adds shared `resolveAnalysisRow` (retry + prefix match) so AI usage CSV save/load uses the same canonical `result_id` as the results page.
- Fixes the post-#202 regression where uploads parsed locally but failed to persist with **"Analysis not found for this result."**
- Closes the first slice of #201 (2.3.3); per-user CSV across re-analyze remains follow-up work on that ticket.

## Test plan
- [x] `npm test -- apps/dashboard/__tests__/resolveAnalysisRow.test.ts apps/dashboard/__tests__/aiUsageRoutes.test.ts` (14 passed)
- [ ] Merge to `dev` and deploy to Railway dev
- [ ] Analyze repo → upload CSV → green "saved for this analysis"
- [ ] Refresh page → CSV reloads without re-upload


Made with [Cursor](https://cursor.com)