### PR TITLE
SIP 2.3.4 Per-user analysis result_id

### DIFF
--- a/apps/dashboard/__tests__/buildAnalysisResultId.test.ts
+++ b/apps/dashboard/__tests__/buildAnalysisResultId.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  analysisResultIdLookupIds,
+  buildAnalysisResultId,
+} from "../lib/buildAnalysisResultId";
+
+const USER_A = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const USER_B = "ffffffff-gggg-hhhh-iiii-jjjjjjjjjjjj";
+
+describe("buildAnalysisResultId", () => {
+  it("prefixes userId so different users get different ids for the same repo", () => {
+    const input = {
+      owner: "scottyUX",
+      repo: "ts-repo-metrics",
+      commitSha: "9fb7133df0dbabcd1234567890abcdef",
+    };
+
+    const idA = buildAnalysisResultId({ userId: USER_A, ...input });
+    const idB = buildAnalysisResultId({ userId: USER_B, ...input });
+
+    expect(idA).toBe(
+      `${USER_A}-scottyUX-ts-repo-metrics-9fb7133df0db`,
+    );
+    expect(idB).toBe(
+      `${USER_B}-scottyUX-ts-repo-metrics-9fb7133df0db`,
+    );
+    expect(idA).not.toBe(idB);
+  });
+
+  it("uses a random suffix when commitSha is null", () => {
+    const id = buildAnalysisResultId({
+      userId: USER_A,
+      owner: "owner",
+      repo: "repo",
+      commitSha: null,
+    });
+
+    expect(id).toMatch(
+      new RegExp(`^${USER_A}-owner-repo-[0-9a-f]{12}$`),
+    );
+  });
+});
+
+describe("analysisResultIdLookupIds", () => {
+  it("returns the requested id first", () => {
+    expect(analysisResultIdLookupIds(USER_A, "owner-repo-abc123")).toEqual([
+      "owner-repo-abc123",
+      `${USER_A}-owner-repo-abc123`,
+    ]);
+  });
+
+  it("does not duplicate prefix when id is already user-scoped", () => {
+    const scoped = `${USER_A}-owner-repo-abc123`;
+    expect(analysisResultIdLookupIds(USER_A, scoped)).toEqual([scoped]);
+  });
+
+  it("returns only the requested id when userId is null", () => {
+    expect(analysisResultIdLookupIds(null, "owner-repo-abc123")).toEqual([
+      "owner-repo-abc123",
+    ]);
+  });
+
+  it("returns empty array for blank ids", () => {
+    expect(analysisResultIdLookupIds(USER_A, "  ")).toEqual([]);
+  });
+});

--- a/apps/dashboard/__tests__/resolveAnalysisRow.test.ts
+++ b/apps/dashboard/__tests__/resolveAnalysisRow.test.ts
@@ -6,12 +6,20 @@ import {
   resolveAnalysisRow,
 } from "../lib/resolveAnalysisRow";
 
+const USER_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
 function makeSupabaseMock(handlers: {
-  exact?: { data: { result_id: string } | null; error?: unknown };
+  exact?: Record<string, { data: { result_id: string } | null; error?: unknown }>;
   prefix?: { data: { result_id: string } | null; error?: unknown };
+  userId?: string | null;
 }) {
-  const eq = vi.fn(() => ({
-    maybeSingle: vi.fn(async () => handlers.exact ?? { data: null, error: null }),
+  const eq = vi.fn((column: string, value: string) => ({
+    maybeSingle: vi.fn(async () => {
+      if (column !== "result_id") {
+        return { data: null, error: null };
+      }
+      return handlers.exact?.[value] ?? { data: null, error: null };
+    }),
   }));
   const like = vi.fn(() => ({
     order: vi.fn(() => ({
@@ -24,7 +32,14 @@ function makeSupabaseMock(handlers: {
   }));
   const select = vi.fn(() => ({ eq, like }));
   const from = vi.fn(() => ({ select }));
-  return { from, eq, like, select };
+  const auth = {
+    getUser: vi.fn(async () => ({
+      data: {
+        user: handlers.userId ? { id: handlers.userId } : null,
+      },
+    })),
+  };
+  return { from, eq, like, select, auth };
 }
 
 describe("resolveAnalysisRow", () => {
@@ -38,7 +53,11 @@ describe("resolveAnalysisRow", () => {
 
   it("returns exact match on first attempt", async () => {
     const sb = makeSupabaseMock({
-      exact: { data: { result_id: "owner-repo-abc123456789" } },
+      exact: {
+        "owner-repo-abc123456789": {
+          data: { result_id: "owner-repo-abc123456789" },
+        },
+      },
     });
 
     const result = await resolveAnalysisRow(
@@ -54,12 +73,33 @@ describe("resolveAnalysisRow", () => {
     expect(sb.like).not.toHaveBeenCalled();
   });
 
+  it("falls back to user-scoped id for legacy urls", async () => {
+    const legacyId = "owner-repo-abc123456789";
+    const scopedId = `${USER_ID}-${legacyId}`;
+    const sb = makeSupabaseMock({
+      userId: USER_ID,
+      exact: {
+        [legacyId]: { data: null, error: null },
+        [scopedId]: { data: { result_id: scopedId } },
+      },
+    });
+
+    const result = await resolveAnalysisRow(legacyId, sb as never);
+
+    expect(result).toEqual({ ok: true, resultId: scopedId });
+    expect(sb.eq).toHaveBeenCalledWith("result_id", legacyId);
+    expect(sb.eq).toHaveBeenCalledWith("result_id", scopedId);
+  });
+
   it("falls back to prefix match when exact match fails", async () => {
     const prefixId = "owner-repo-abc123456789";
     const shortPrefix = prefixId.slice(0, MIN_PARTIAL_RESULT_ID_LENGTH);
 
     const sb = makeSupabaseMock({
-      exact: { data: null, error: null },
+      exact: {
+        [prefixId]: { data: null, error: null },
+        [`${USER_ID}-${prefixId}`]: { data: null, error: null },
+      },
       prefix: { data: { result_id: prefixId } },
     });
 
@@ -76,7 +116,10 @@ describe("resolveAnalysisRow", () => {
 
   it("skips prefix match for short ids", async () => {
     const sb = makeSupabaseMock({
-      exact: { data: null, error: null },
+      exact: {
+        "short-id": { data: null, error: null },
+        [`${USER_ID}-short-id`]: { data: null, error: null },
+      },
     });
 
     const promise = resolveAnalysisRow("short-id", sb as never);
@@ -91,7 +134,10 @@ describe("resolveAnalysisRow", () => {
 
   it("returns not_found when no row matches", async () => {
     const sb = makeSupabaseMock({
-      exact: { data: null, error: null },
+      exact: {
+        "owner-repo-abc123456789": { data: null, error: null },
+        [`${USER_ID}-owner-repo-abc123456789`]: { data: null, error: null },
+      },
       prefix: { data: null, error: null },
     });
 

--- a/apps/dashboard/app/api/analyze/route.ts
+++ b/apps/dashboard/app/api/analyze/route.ts
@@ -12,6 +12,7 @@ import { NextRequest, NextResponse } from "next/server";
 import path from "node:path";
 import os from "node:os";
 import { randomUUID } from "node:crypto";
+import { buildAnalysisResultId } from "@/lib/buildAnalysisResultId";
 import {
   getSupabase,
   isSupabaseConfigured,
@@ -216,12 +217,14 @@ export async function POST(request: NextRequest) {
 
     let resultId: string;
     if (parsed) {
-      const suffix = commitSha
-        ? commitSha.slice(0, 12)
-        : randomUUID().replace(/-/g, "").slice(0, 12);
-      resultId = `${parsed.owner}-${parsed.repo}-${suffix}`;
+      resultId = buildAnalysisResultId({
+        userId: authUser.id,
+        owner: parsed.owner,
+        repo: parsed.repo,
+        commitSha,
+      });
     } else {
-      resultId = randomUUID();
+      resultId = `${authUser.id}-${randomUUID()}`;
     }
 
     const submissionPayload = {

--- a/apps/dashboard/app/api/results/[id]/route.ts
+++ b/apps/dashboard/app/api/results/[id]/route.ts
@@ -16,11 +16,29 @@ import {
   isUserSupabaseConfigured,
 } from "@/lib/supabase/server-user";
 import { devGetReport } from "@/lib/devReportStore";
+import { analysisResultIdLookupIds } from "@/lib/buildAnalysisResultId";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 const isDev = process.env.NODE_ENV === "development";
 
-/** Avoid broad prefix scans on very short strings (IDs are owner-repo-commit, typically longer). */
+/** Avoid broad prefix scans on very short strings (IDs are user-owner-repo-commit, typically longer). */
 const MIN_PARTIAL_RESULT_ID_LENGTH = 20;
+
+async function fetchReportByExactId(
+  supabase: SupabaseClient,
+  candidateId: string,
+): Promise<{ report_json: unknown; result_id: string } | null> {
+  const { data, error } = await supabase
+    .from("analyses")
+    .select("report_json, result_id")
+    .eq("result_id", candidateId)
+    .single();
+
+  if (data && !error) {
+    return data;
+  }
+  return null;
+}
 
 export async function GET(
   _request: NextRequest,
@@ -47,28 +65,36 @@ export async function GET(
       ? await createUserSupabaseServerClient()
       : getSupabase();
 
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    const lookupIds = analysisResultIdLookupIds(user?.id ?? null, trimmedId);
+
     // Retry logic to handle race condition (Supabase replication delay)
     const maxRetries = 3;
     const retryDelay = 500; // ms
-    let data = null;
-    let error = null;
+    let data: { report_json: unknown; result_id: string } | null = null;
+    let error: { message: string; code?: string; details?: string } | null =
+      null;
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      const result = await supabase
-        .from("analyses")
-        .select("report_json, result_id")
-        .eq("result_id", trimmedId)
-        .single();
-      
-      data = result.data;
-      error = result.error;
+      for (const candidateId of lookupIds) {
+        const match = await fetchReportByExactId(supabase, candidateId);
+        if (match) {
+          data = match;
+          error = null;
+          break;
+        }
+      }
 
-      if (data && !error) {
+      if (data) {
         if (isDev) {
           console.log(`[results] Found on attempt ${attempt}`);
         }
         return NextResponse.json(data.report_json);
       }
+
+      error = { message: "Result not found" };
 
       // If not found and not last attempt, wait and retry
       if (attempt < maxRetries) {

--- a/apps/dashboard/lib/buildAnalysisResultId.ts
+++ b/apps/dashboard/lib/buildAnalysisResultId.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from "node:crypto";
+
+export type BuildAnalysisResultIdInput = {
+  userId: string;
+  owner: string;
+  repo: string;
+  commitSha: string | null;
+};
+
+/** Build a per-user analysis result_id: {userId}-{owner}-{repo}-{commitSuffix}. */
+export function buildAnalysisResultId({
+  userId,
+  owner,
+  repo,
+  commitSha,
+}: BuildAnalysisResultIdInput): string {
+  const suffix = commitSha
+    ? commitSha.slice(0, 12)
+    : randomUUID().replace(/-/g, "").slice(0, 12);
+  return `${userId}-${owner}-${repo}-${suffix}`;
+}
+
+/**
+ * Candidate result_ids to try when resolving a stored analysis row.
+ * Supports legacy URLs (owner-repo-commit) for signed-in users who re-analyzed
+ * after the per-user result_id change.
+ */
+export function analysisResultIdLookupIds(
+  userId: string | null,
+  requestedId: string,
+): string[] {
+  const trimmed = requestedId.trim();
+  if (!trimmed) return [];
+
+  const candidates = [trimmed];
+  if (userId && !trimmed.startsWith(`${userId}-`)) {
+    candidates.push(`${userId}-${trimmed}`);
+  }
+  return candidates;
+}

--- a/apps/dashboard/lib/getReportById.ts
+++ b/apps/dashboard/lib/getReportById.ts
@@ -12,11 +12,29 @@ import {
   createUserSupabaseServerClient,
   isUserSupabaseConfigured,
 } from "@/lib/supabase/server-user";
+import { analysisResultIdLookupIds } from "@/lib/buildAnalysisResultId";
 import { devGetReport } from "@/lib/devReportStore";
 import type { RepoReport } from "@/lib/reportTypes";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 500;
+
+async function fetchReportJsonByExactId(
+  supabase: SupabaseClient,
+  candidateId: string,
+): Promise<RepoReport | null> {
+  const { data, error } = await supabase
+    .from("analyses")
+    .select("report_json")
+    .eq("result_id", candidateId)
+    .single();
+
+  if (data && !error) {
+    return data.report_json as RepoReport;
+  }
+  return null;
+}
 
 export async function getReportById(id: string): Promise<{
   data: RepoReport | null;
@@ -37,15 +55,17 @@ export async function getReportById(id: string): Promise<{
       ? await createUserSupabaseServerClient()
       : getSupabase();
 
-    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-      const { data, error } = await supabase
-        .from("analyses")
-        .select("report_json")
-        .eq("result_id", trimmedId)
-        .single();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    const lookupIds = analysisResultIdLookupIds(user?.id ?? null, trimmedId);
 
-      if (data && !error) {
-        return { data: data.report_json as RepoReport, error: null };
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      for (const candidateId of lookupIds) {
+        const report = await fetchReportJsonByExactId(supabase, candidateId);
+        if (report) {
+          return { data: report, error: null };
+        }
       }
 
       if (attempt < MAX_RETRIES) {

--- a/apps/dashboard/lib/resolveAnalysisRow.ts
+++ b/apps/dashboard/lib/resolveAnalysisRow.ts
@@ -4,6 +4,7 @@
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { analysisResultIdLookupIds } from "@/lib/buildAnalysisResultId";
 
 export const ANALYSIS_ROW_MAX_RETRIES = 3;
 export const ANALYSIS_ROW_RETRY_DELAY_MS = 500;
@@ -12,6 +13,22 @@ export const MIN_PARTIAL_RESULT_ID_LENGTH = 20;
 export type ResolveAnalysisRowResult =
   | { ok: true; resultId: string }
   | { ok: false; code: "not_found" };
+
+async function fetchExactResultId(
+  supabase: SupabaseClient,
+  candidateId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("analyses")
+    .select("result_id")
+    .eq("result_id", candidateId)
+    .maybeSingle();
+
+  if (data?.result_id && !error) {
+    return data.result_id;
+  }
+  return null;
+}
 
 export async function resolveAnalysisRow(
   requestedId: string,
@@ -22,15 +39,17 @@ export async function resolveAnalysisRow(
     return { ok: false, code: "not_found" };
   }
 
-  for (let attempt = 1; attempt <= ANALYSIS_ROW_MAX_RETRIES; attempt++) {
-    const { data, error } = await supabase
-      .from("analyses")
-      .select("result_id")
-      .eq("result_id", trimmedId)
-      .maybeSingle();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const lookupIds = analysisResultIdLookupIds(user?.id ?? null, trimmedId);
 
-    if (data?.result_id && !error) {
-      return { ok: true, resultId: data.result_id };
+  for (let attempt = 1; attempt <= ANALYSIS_ROW_MAX_RETRIES; attempt++) {
+    for (const candidateId of lookupIds) {
+      const resultId = await fetchExactResultId(supabase, candidateId);
+      if (resultId) {
+        return { ok: true, resultId };
+      }
     }
 
     if (attempt < ANALYSIS_ROW_MAX_RETRIES) {


### PR DESCRIPTION
## Summary
- Prefix `result_id` with the signed-in user's UUID (`{userId}-{owner}-{repo}-{commit}`) so multiple students analyzing the same shared repo at the same commit no longer overwrite one `analyses` row.
- Add `analysisResultIdLookupIds` fallback in results fetch, `resolveAnalysisRow`, and the results API so legacy `owner-repo-commit` URLs still resolve for the same user after re-analyze.
- Code-only fix — no Supabase migration required.

Closes #209

Parent: #193 (SIP-2.3)

## Test plan
- [ ] Sign in as User A → analyze `scottyUX/ts-repo-metrics` → note `resultId` in URL
- [ ] Sign in as User B → analyze same repo → different `resultId`; both users can open their own results pages
- [ ] Upload AI usage CSV on each user's results page → save succeeds and persists on refresh
- [ ] `npm test -- buildAnalysisResultId resolveAnalysisRow` from repo root

Made with [Cursor](https://cursor.com)