### PR TITLE
Fix results route TypeScript never-type build failure

### DIFF
--- a/apps/dashboard/app/api/results/[id]/route.ts
+++ b/apps/dashboard/app/api/results/[id]/route.ts
@@ -132,42 +132,31 @@ export async function GET(
       }
     }
 
-    // Final error handling
+    // Exact + prefix lookups failed — nothing left to return.
     if (error) {
       console.error("[results] Supabase error:", error.message, error.code, error.details);
-      if (isDev) {
-        const { data: all } = await supabase
-          .from("analyses")
-          .select("result_id")
-          .limit(10);
-        if (isDev) {
-          console.log(
-            "[results] Available result_ids:",
-            all?.map((r) => r.result_id),
-          );
-        }
-        return NextResponse.json(
-          {
-            error: "Result not found",
-            debug: { searched: trimmedId, available: all?.map((r) => r.result_id) },
-          },
-          { status: 404 },
-        );
-      }
-      return NextResponse.json({ error: "Result not found" }, { status: 404 });
-    }
-
-    if (!data) {
-      if (isDev) {
-        console.log("[results] No row found for id:", trimmedId);
-      }
-      return NextResponse.json({ error: "Result not found" }, { status: 404 });
+    } else if (isDev) {
+      console.log("[results] No row found for id:", trimmedId);
     }
 
     if (isDev) {
-      console.log("[results] Found report for id:", trimmedId);
+      const { data: all } = await supabase
+        .from("analyses")
+        .select("result_id")
+        .limit(10);
+      console.log(
+        "[results] Available result_ids:",
+        all?.map((r) => r.result_id),
+      );
+      return NextResponse.json(
+        {
+          error: "Result not found",
+          debug: { searched: trimmedId, available: all?.map((r) => r.result_id) },
+        },
+        { status: 404 },
+      );
     }
-    return NextResponse.json(data.report_json);
+    return NextResponse.json({ error: "Result not found" }, { status: 404 });
   } catch (err) {
     console.error("[results] Exception:", err);
     const body: { error: string; details?: string } = {


### PR DESCRIPTION
## Summary
- Fixes the TypeScript build error introduced by #210: `Property 'report_json' does not exist on type 'never'` in `GET /api/results/[id]`.
- After lookup retries fail, `error` is always set and `data` is null, so the old success return was unreachable and broke `next build`.

Follow-up to #210 / #209 (SIP 2.3.4).

## Test plan
- [ ] `cd apps/dashboard && npm run build` succeeds
- [ ] Railway/Vercel deploy for this branch passes the Next.js build step

Made with [Cursor](https://cursor.com)