### PR TITLE
Fix per-user analyze and AI usage CSV saves for shared repos

### DIFF
--- a/apps/dashboard/__tests__/aiUsageRoutes.test.ts
+++ b/apps/dashboard/__tests__/aiUsageRoutes.test.ts
@@ -44,15 +44,20 @@ vi.mock("@/lib/resolveAnalysisRow", () => ({
 }));
 
 const CANONICAL_ID = "owner-repo-abc123456789";
+const LEGACY_ID = "owner-repo-abc";
+const USER_A = "user-a";
+const USER_B = "user-b";
 const CSV =
   "timestamp,event_type,session_id,tool_name\n2026-05-20T10:00:00.000Z,user_prompt,s1,\n";
+const CSV_B =
+  "timestamp,event_type,session_id,tool_name\n2026-05-21T10:00:00.000Z,user_prompt,s2,\n";
 
 describe("ai usage routes — dev fallback mode", () => {
   beforeEach(async () => {
     vi.resetModules();
     getUser.mockReset();
     fromFn.mockClear();
-    getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    getUser.mockResolvedValue({ data: { user: { id: USER_A } } });
 
     const { isDevReportMemoryFallback, isSupabaseConfigured } = await import(
       "@/lib/supabase/server"
@@ -68,25 +73,64 @@ describe("ai usage routes — dev fallback mode", () => {
     const postRes = await POST(
       new NextRequest("http://localhost/api/ai-usage", {
         method: "POST",
-        body: JSON.stringify({ resultId: "owner-repo-abc", csvText: CSV }),
+        body: JSON.stringify({ resultId: LEGACY_ID, csvText: CSV }),
         headers: { "Content-Type": "application/json" },
       }),
     );
     expect(postRes.status).toBe(200);
     await expect(postRes.json()).resolves.toEqual({
-      resultId: "owner-repo-abc",
+      resultId: `${USER_A}-${LEGACY_ID}`,
       csvText: CSV,
     });
 
     const getRes = await GET(
       new NextRequest("http://localhost/api/results/owner-repo-abc/ai-usage"),
-      { params: Promise.resolve({ id: "owner-repo-abc" }) },
+      { params: Promise.resolve({ id: LEGACY_ID }) },
     );
     expect(getRes.status).toBe(200);
     await expect(getRes.json()).resolves.toEqual({
-      resultId: "owner-repo-abc",
+      resultId: `${USER_A}-${LEGACY_ID}`,
       csvText: CSV,
     });
+  });
+
+  it("does not overwrite another user's CSV for the same repo", async () => {
+    const { POST } = await import("../app/api/ai-usage/route");
+    const { GET } = await import("../app/api/results/[id]/ai-usage/route");
+
+    getUser.mockResolvedValueOnce({ data: { user: { id: USER_A } } });
+    await POST(
+      new NextRequest("http://localhost/api/ai-usage", {
+        method: "POST",
+        body: JSON.stringify({ resultId: LEGACY_ID, csvText: CSV }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    getUser.mockResolvedValueOnce({ data: { user: { id: USER_B } } });
+    await POST(
+      new NextRequest("http://localhost/api/ai-usage", {
+        method: "POST",
+        body: JSON.stringify({ resultId: LEGACY_ID, csvText: CSV_B }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    getUser.mockResolvedValueOnce({ data: { user: { id: USER_A } } });
+    const getA = await GET(
+      new NextRequest("http://localhost/api/results/owner-repo-abc/ai-usage"),
+      { params: Promise.resolve({ id: LEGACY_ID }) },
+    );
+    expect(getA.status).toBe(200);
+    await expect(getA.json()).resolves.toMatchObject({ csvText: CSV });
+
+    getUser.mockResolvedValueOnce({ data: { user: { id: USER_B } } });
+    const getB = await GET(
+      new NextRequest("http://localhost/api/results/owner-repo-abc/ai-usage"),
+      { params: Promise.resolve({ id: LEGACY_ID }) },
+    );
+    expect(getB.status).toBe(200);
+    await expect(getB.json()).resolves.toMatchObject({ csvText: CSV_B });
   });
 
   it("rejects empty uploads", async () => {
@@ -114,7 +158,7 @@ describe("ai usage routes — Supabase mode", () => {
     resolveAnalysisRow.mockReset();
     Object.keys(tableResults).forEach((k) => delete tableResults[k]);
 
-    getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    getUser.mockResolvedValue({ data: { user: { id: USER_A } } });
     resolveAnalysisRow.mockResolvedValue({
       ok: true,
       resultId: CANONICAL_ID,
@@ -149,7 +193,11 @@ describe("ai usage routes — Supabase mode", () => {
 
     const tables = fromFn.mock.calls.map(([table]: [string]) => table);
     expect(tables).toContain("ai_usage_csvs");
-    expect(resolveAnalysisRow).toHaveBeenCalled();
+    expect(resolveAnalysisRow).toHaveBeenCalledWith(
+      "owner-repo-abc12345",
+      expect.anything(),
+      { preferUserScope: true },
+    );
   });
 
   it("returns 404 when analysis does not exist", async () => {

--- a/apps/dashboard/__tests__/buildAnalysisResultId.test.ts
+++ b/apps/dashboard/__tests__/buildAnalysisResultId.test.ts
@@ -63,4 +63,12 @@ describe("analysisResultIdLookupIds", () => {
   it("returns empty array for blank ids", () => {
     expect(analysisResultIdLookupIds(USER_A, "  ")).toEqual([]);
   });
+
+  it("prefers user-scoped id before legacy id when requested", () => {
+    expect(
+      analysisResultIdLookupIds(USER_A, "owner-repo-abc123", {
+        preferUserScope: true,
+      }),
+    ).toEqual([`${USER_A}-owner-repo-abc123`, "owner-repo-abc123"]);
+  });
 });

--- a/apps/dashboard/__tests__/resolveAnalysisRow.test.ts
+++ b/apps/dashboard/__tests__/resolveAnalysisRow.test.ts
@@ -91,6 +91,26 @@ describe("resolveAnalysisRow", () => {
     expect(sb.eq).toHaveBeenCalledWith("result_id", scopedId);
   });
 
+  it("prefers user-scoped id when both legacy and scoped rows exist", async () => {
+    const legacyId = "owner-repo-abc123456789";
+    const scopedId = `${USER_ID}-${legacyId}`;
+    const sb = makeSupabaseMock({
+      userId: USER_ID,
+      exact: {
+        [scopedId]: { data: { result_id: scopedId } },
+        [legacyId]: { data: { result_id: legacyId } },
+      },
+    });
+
+    const result = await resolveAnalysisRow(legacyId, sb as never, {
+      preferUserScope: true,
+    });
+
+    expect(result).toEqual({ ok: true, resultId: scopedId });
+    expect(sb.eq).toHaveBeenCalledWith("result_id", scopedId);
+    expect(sb.eq).not.toHaveBeenCalledWith("result_id", legacyId);
+  });
+
   it("falls back to prefix match when exact match fails", async () => {
     const prefixId = "owner-repo-abc123456789";
     const shortPrefix = prefixId.slice(0, MIN_PARTIAL_RESULT_ID_LENGTH);

--- a/apps/dashboard/app/api/ai-usage/route.ts
+++ b/apps/dashboard/app/api/ai-usage/route.ts
@@ -17,7 +17,10 @@ import {
 } from "@/lib/supabase/server-user";
 import { ANALYZE_SIGN_IN_REQUIRED_MESSAGE } from "@/lib/analyzeConstants";
 import { devStoreAiUsageCsv } from "@/lib/devAiUsageStore";
+import { userScopedResultId } from "@/lib/buildAnalysisResultId";
 import { resolveAnalysisRow } from "@/lib/resolveAnalysisRow";
+
+const AI_USAGE_RESOLVE_OPTIONS = { preferUserScope: true } as const;
 
 const AI_USAGE_MIGRATION_HINT =
   "Run supabase/migrations/20260702000000_ai_usage_csvs_per_user.sql in the Supabase SQL Editor.";
@@ -90,7 +93,11 @@ export async function POST(request: NextRequest) {
     let savedResultId = resultId;
 
     if (isSupabaseConfigured()) {
-      const resolved = await resolveAnalysisRow(resultId, userSb);
+      const resolved = await resolveAnalysisRow(
+        resultId,
+        userSb,
+        AI_USAGE_RESOLVE_OPTIONS,
+      );
       if (!resolved.ok) {
         return NextResponse.json(
           { error: "Analysis not found for this result.", code: "not_found" },
@@ -126,7 +133,9 @@ export async function POST(request: NextRequest) {
         );
       }
     } else if (isDevReportMemoryFallback()) {
-      devStoreAiUsageCsv(resultId, csvText);
+      const scopedResultId = userScopedResultId(user.id, resultId);
+      devStoreAiUsageCsv(user.id, scopedResultId, csvText);
+      savedResultId = scopedResultId;
     } else {
       return NextResponse.json(
         { error: "Storage is not configured." },

--- a/apps/dashboard/app/api/analyze/route.ts
+++ b/apps/dashboard/app/api/analyze/route.ts
@@ -63,6 +63,21 @@ function analysesUpsertLooksLikeStaleSchema(error: {
 const ANALYSES_MIGRATION_HINT =
   "Add columns on public.analyses: run supabase/migrations/20260522000000_analyses_course_metadata.sql in the Supabase SQL Editor (or the full snippet in supabase/run_in_dashboard_sql_editor.sql).";
 
+const ANALYSES_REPO_COMMIT_UNIQUE_HINT =
+  "Run supabase/migrations/20260707120000_drop_analyses_repo_commit_unique.sql in the Supabase SQL Editor (or the full snippet in supabase/run_in_dashboard_sql_editor.sql).";
+
+function analysesUpsertLooksLikeRepoCommitUnique(error: {
+  message?: string;
+  code?: string | null;
+  details?: string | null;
+}): boolean {
+  const blob = `${error.message ?? ""} ${error.details ?? ""}`;
+  return (
+    error.code === "23505" &&
+    /\banalyses_repo_commit_unique\b/i.test(blob)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Course allow-list
 // Add a new entry here whenever a new course section is created.
@@ -250,19 +265,40 @@ export async function POST(request: NextRequest) {
         github_login: githubLogin,
       };
 
+      // Replace any legacy row for this user+repo+commit (old result_id format).
+      if (userId && commitSha) {
+        const { error: deleteError } = await getSupabase()
+          .from("analyses")
+          .delete()
+          .eq("user_id", userId)
+          .eq("repo_url", normalizedUrl)
+          .eq("commit_sha", commitSha);
+
+        if (deleteError) {
+          console.error("[analyze] Supabase delete legacy row failed:", deleteError);
+        }
+      }
+
       const { error } = await getSupabase()
         .from("analyses")
         .upsert(row, { onConflict: "result_id" });
 
       if (error) {
         console.error("[analyze] Supabase upsert failed:", error);
+        const repoCommitUnique = analysesUpsertLooksLikeRepoCommitUnique(error);
         const schemaStale = analysesUpsertLooksLikeStaleSchema(error);
         const respBody: Record<string, unknown> = {
-          error: schemaStale
-            ? "Could not save the report: database is missing newer columns."
-            : "Failed to save result.",
+          error: repoCommitUnique
+            ? "Could not save the report: database still enforces one row per repo+commit for all users."
+            : schemaStale
+              ? "Could not save the report: database is missing newer columns."
+              : "Failed to save result.",
           status: "failed",
         };
+        if (repoCommitUnique) {
+          respBody.code = "analyses_repo_commit_unique";
+          respBody.hint = ANALYSES_REPO_COMMIT_UNIQUE_HINT;
+        }
         if (schemaStale) {
           respBody.code = "analyses_schema_mismatch";
           respBody.hint = ANALYSES_MIGRATION_HINT;

--- a/apps/dashboard/app/api/results/[id]/ai-usage/route.ts
+++ b/apps/dashboard/app/api/results/[id]/ai-usage/route.ts
@@ -14,7 +14,10 @@ import {
   isUserSupabaseConfigured,
 } from "@/lib/supabase/server-user";
 import { devGetAiUsageCsv } from "@/lib/devAiUsageStore";
+import { userScopedResultId } from "@/lib/buildAnalysisResultId";
 import { resolveAnalysisRow } from "@/lib/resolveAnalysisRow";
+
+const AI_USAGE_RESOLVE_OPTIONS = { preferUserScope: true } as const;
 
 export async function GET(
   _request: NextRequest,
@@ -24,8 +27,29 @@ export async function GET(
   const resultId = id.trim();
 
   if (isDevReportMemoryFallback()) {
-    const cached = devGetAiUsageCsv(resultId);
-    if (cached) return NextResponse.json({ resultId, csvText: cached });
+    if (!isUserSupabaseConfigured()) {
+      return NextResponse.json(
+        { error: "Storage is not configured." },
+        { status: 503 },
+      );
+    }
+
+    const userSb = await createUserSupabaseServerClient();
+    const {
+      data: { user },
+    } = await userSb.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const scopedResultId = userScopedResultId(user.id, resultId);
+    const cached =
+      devGetAiUsageCsv(user.id, scopedResultId) ??
+      devGetAiUsageCsv(user.id, resultId);
+    if (cached) {
+      return NextResponse.json({ resultId: scopedResultId, csvText: cached });
+    }
     return NextResponse.json({ error: "AI usage not found" }, { status: 404 });
   }
 
@@ -45,7 +69,11 @@ export async function GET(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const resolved = await resolveAnalysisRow(resultId, userSb);
+  const resolved = await resolveAnalysisRow(
+    resultId,
+    userSb,
+    AI_USAGE_RESOLVE_OPTIONS,
+  );
   if (!resolved.ok) {
     return NextResponse.json({ error: "AI usage not found" }, { status: 404 });
   }

--- a/apps/dashboard/lib/buildAnalysisResultId.ts
+++ b/apps/dashboard/lib/buildAnalysisResultId.ts
@@ -20,6 +20,14 @@ export function buildAnalysisResultId({
   return `${userId}-${owner}-${repo}-${suffix}`;
 }
 
+export type AnalysisResultIdLookupOptions = {
+  /**
+   * When true, try the signed-in user's scoped id before a legacy shared id.
+   * Use for AI usage CSV persistence so uploads stay on per-user analysis rows.
+   */
+  preferUserScope?: boolean;
+};
+
 /**
  * Candidate result_ids to try when resolving a stored analysis row.
  * Supports legacy URLs (owner-repo-commit) for signed-in users who re-analyzed
@@ -28,13 +36,32 @@ export function buildAnalysisResultId({
 export function analysisResultIdLookupIds(
   userId: string | null,
   requestedId: string,
+  options?: AnalysisResultIdLookupOptions,
 ): string[] {
   const trimmed = requestedId.trim();
   if (!trimmed) return [];
 
-  const candidates = [trimmed];
-  if (userId && !trimmed.startsWith(`${userId}-`)) {
-    candidates.push(`${userId}-${trimmed}`);
+  const scoped =
+    userId && !trimmed.startsWith(`${userId}-`)
+      ? `${userId}-${trimmed}`
+      : null;
+
+  if (options?.preferUserScope) {
+    if (!scoped) return [trimmed];
+    return [scoped, trimmed];
   }
+
+  const candidates = [trimmed];
+  if (scoped) candidates.push(scoped);
   return candidates;
+}
+
+/** Map a legacy/shared result_id to the signed-in user's scoped id for storage keys. */
+export function userScopedResultId(
+  userId: string,
+  resultId: string,
+): string {
+  const trimmed = resultId.trim();
+  if (!trimmed || trimmed.startsWith(`${userId}-`)) return trimmed;
+  return `${userId}-${trimmed}`;
 }

--- a/apps/dashboard/lib/devAiUsageStore.ts
+++ b/apps/dashboard/lib/devAiUsageStore.ts
@@ -1,18 +1,30 @@
 /**
  * In-memory AI usage CSV cache when Supabase is not configured (local dev only).
+ * Keys include userId so uploads for the same repo do not overwrite other users.
  */
 
 const MAX_ENTRIES = 50;
 const store = new Map<string, string>();
 
-export function devStoreAiUsageCsv(resultId: string, csvText: string): void {
+function devAiUsageKey(userId: string, resultId: string): string {
+  return `${userId}:${resultId.trim()}`;
+}
+
+export function devStoreAiUsageCsv(
+  userId: string,
+  resultId: string,
+  csvText: string,
+): void {
   if (store.size >= MAX_ENTRIES) {
     const oldest = store.keys().next().value;
     if (oldest) store.delete(oldest);
   }
-  store.set(resultId.trim(), csvText);
+  store.set(devAiUsageKey(userId, resultId), csvText);
 }
 
-export function devGetAiUsageCsv(resultId: string): string | null {
-  return store.get(resultId.trim()) ?? null;
+export function devGetAiUsageCsv(
+  userId: string,
+  resultId: string,
+): string | null {
+  return store.get(devAiUsageKey(userId, resultId)) ?? null;
 }

--- a/apps/dashboard/lib/resolveAnalysisRow.ts
+++ b/apps/dashboard/lib/resolveAnalysisRow.ts
@@ -4,7 +4,10 @@
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { analysisResultIdLookupIds } from "@/lib/buildAnalysisResultId";
+import {
+  type AnalysisResultIdLookupOptions,
+  analysisResultIdLookupIds,
+} from "@/lib/buildAnalysisResultId";
 
 export const ANALYSIS_ROW_MAX_RETRIES = 3;
 export const ANALYSIS_ROW_RETRY_DELAY_MS = 500;
@@ -33,6 +36,7 @@ async function fetchExactResultId(
 export async function resolveAnalysisRow(
   requestedId: string,
   supabase: SupabaseClient,
+  options?: AnalysisResultIdLookupOptions,
 ): Promise<ResolveAnalysisRowResult> {
   const trimmedId = requestedId.trim();
   if (!trimmedId) {
@@ -42,7 +46,11 @@ export async function resolveAnalysisRow(
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  const lookupIds = analysisResultIdLookupIds(user?.id ?? null, trimmedId);
+  const lookupIds = analysisResultIdLookupIds(
+    user?.id ?? null,
+    trimmedId,
+    options,
+  );
 
   for (let attempt = 1; attempt <= ANALYSIS_ROW_MAX_RETRIES; attempt++) {
     for (const candidateId of lookupIds) {
@@ -60,16 +68,25 @@ export async function resolveAnalysisRow(
   }
 
   if (trimmedId.length >= MIN_PARTIAL_RESULT_ID_LENGTH) {
-    const { data, error } = await supabase
-      .from("analyses")
-      .select("result_id")
-      .like("result_id", `${trimmedId}%`)
-      .order("analyzed_at", { ascending: false })
-      .limit(1)
-      .maybeSingle();
+    const prefixCandidates =
+      options?.preferUserScope && user?.id
+        ? !trimmedId.startsWith(`${user.id}-`)
+          ? [`${user.id}-${trimmedId}`, trimmedId]
+          : [trimmedId]
+        : [trimmedId];
 
-    if (data?.result_id && !error) {
-      return { ok: true, resultId: data.result_id };
+    for (const prefix of prefixCandidates) {
+      const { data, error } = await supabase
+        .from("analyses")
+        .select("result_id")
+        .like("result_id", `${prefix}%`)
+        .order("analyzed_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (data?.result_id && !error) {
+        return { ok: true, resultId: data.result_id };
+      }
     }
   }
 

--- a/supabase/migrations/20260707120000_drop_analyses_repo_commit_unique.sql
+++ b/supabase/migrations/20260707120000_drop_analyses_repo_commit_unique.sql
@@ -1,0 +1,7 @@
+-- Drop legacy unique constraint on (repo_url, commit_sha) alone.
+-- Per-user result_id (SIP 2.3.4) requires multiple rows for the same repo snapshot
+-- when different users analyze the same public repo at the same commit.
+-- This constraint was not in repo migrations; it was added manually on hosted Supabase.
+
+alter table public.analyses
+  drop constraint if exists analyses_repo_commit_unique;

--- a/supabase/run_in_dashboard_sql_editor.sql
+++ b/supabase/run_in_dashboard_sql_editor.sql
@@ -53,3 +53,7 @@ alter table public.analyses
 
 comment on column public.analyses.doc_review_json is
   'Documentation review agent output (classifications, reviews, consistency). Nullable.';
+
+-- Per-user analyses (SIP 2.3.4): allow multiple users on same repo+commit.
+alter table public.analyses
+  drop constraint if exists analyses_repo_commit_unique;


### PR DESCRIPTION
## Summary
- **Analyze saves:** Root cause of **Failed to save result** on dev was Postgres error `23505` on `analyses_repo_commit_unique` — only one row allowed per `(repo_url, commit_sha)` for all users. SIP 2.3.4 gives each user a unique `result_id`, but inserts still hit that legacy constraint when another user already analyzed the same commit.
- **AI usage CSVs:** Uploads could still attach to the legacy shared `result_id` (`owner-repo-commit`) instead of the signed-in user's scoped row, and local dev stored CSVs in memory keyed only by `result_id` — so same-repo uploads could overwrite another user's trace.

### Changes
- Drop `analyses_repo_commit_unique` via migration; delete prior row for same `user_id + repo_url + commit_sha` before upsert (cleans legacy ids).
- Return a clear API error + hint when the constraint is still present.
- AI usage routes now resolve analyses with `preferUserScope: true` so uploads land on `{userId}-owner-repo-commit` rows.
- Dev in-memory AI usage store keys by `userId + result_id`; dev GET requires auth.

## Required: run migration on Supabase
After merge, run in Supabase SQL Editor:

```sql
alter table public.analyses drop constraint if exists analyses_repo_commit_unique;
```

Also ensure the per-user AI usage table exists:

```sql
-- Or run full migration: supabase/migrations/20260702000000_ai_usage_csvs_per_user.sql
```

Or: `supabase db push` / paste updated `supabase/run_in_dashboard_sql_editor.sql`.

Refs #209

## Test plan
- [ ] Run migration on shared Supabase project
- [ ] User A analyzes `scottyUX/ts-repo-metrics` → save succeeds
- [ ] User B analyzes same repo at same commit → save succeeds (distinct `result_id`)
- [ ] Same user re-analyzes → replaces their prior analysis row
- [ ] User A uploads `ai_usage_trace.csv` on their analysis → metrics load
- [ ] User B uploads on the same repo/commit → User A still sees their own CSV (not B's)
- [ ] Re-uploading your own CSV replaces only your prior upload