### PR TITLE
SIP 2.3.5 Versioned analyses per user+repo

### DIFF
--- a/apps/dashboard/__tests__/analysisVersion.test.ts
+++ b/apps/dashboard/__tests__/analysisVersion.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { nextAnalysisVersion } from "../lib/analysisVersion";
+import {
+  maxAnalysisVersion,
+  nextAnalysisVersion,
+} from "../lib/analysisVersion";
+
+describe("maxAnalysisVersion", () => {
+  it("ignores nulls and returns the highest numeric version", () => {
+    expect(
+      maxAnalysisVersion([{ version: null }, { version: 1 }, { version: 2 }]),
+    ).toBe(2);
+  });
+
+  it("returns null for empty or all-null rows", () => {
+    expect(maxAnalysisVersion([])).toBeNull();
+    expect(
+      maxAnalysisVersion([{ version: null }, { version: undefined }]),
+    ).toBeNull();
+  });
+
+  it("returns a single version when only one is present", () => {
+    expect(maxAnalysisVersion([{ version: 1 }])).toBe(1);
+  });
+});
 
 describe("nextAnalysisVersion", () => {
   it("returns version 1 when there is no prior analysis", () => {

--- a/apps/dashboard/__tests__/analysisVersion.test.ts
+++ b/apps/dashboard/__tests__/analysisVersion.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { nextAnalysisVersion } from "../lib/analysisVersion";
+
+describe("nextAnalysisVersion", () => {
+  it("returns version 1 when there is no prior analysis", () => {
+    expect(
+      nextAnalysisVersion({
+        latestCommit: null,
+        latestVersion: null,
+        maxVersion: null,
+        newCommit: "abc123",
+      }),
+    ).toEqual({ version: 1, sameCommit: false });
+  });
+
+  it("keeps the latest version when commit matches", () => {
+    expect(
+      nextAnalysisVersion({
+        latestCommit: "abc123def456",
+        latestVersion: 3,
+        maxVersion: 3,
+        newCommit: "abc123def456",
+      }),
+    ).toEqual({ version: 3, sameCommit: true });
+  });
+
+  it("bumps to max+1 when commit differs", () => {
+    expect(
+      nextAnalysisVersion({
+        latestCommit: "oldcommit000",
+        latestVersion: 2,
+        maxVersion: 2,
+        newCommit: "newcommit111",
+      }),
+    ).toEqual({ version: 3, sameCommit: false });
+  });
+
+  it("bumps when new commit is null", () => {
+    expect(
+      nextAnalysisVersion({
+        latestCommit: "abc123",
+        latestVersion: 1,
+        maxVersion: 1,
+        newCommit: null,
+      }),
+    ).toEqual({ version: 2, sameCommit: false });
+  });
+
+  it("bumps when latest commit is null", () => {
+    expect(
+      nextAnalysisVersion({
+        latestCommit: null,
+        latestVersion: 1,
+        maxVersion: 1,
+        newCommit: "abc123",
+      }),
+    ).toEqual({ version: 2, sameCommit: false });
+  });
+
+  it("uses maxVersion when same commit but latestVersion is missing", () => {
+    expect(
+      nextAnalysisVersion({
+        latestCommit: "abc123",
+        latestVersion: null,
+        maxVersion: 4,
+        newCommit: "abc123",
+      }),
+    ).toEqual({ version: 4, sameCommit: true });
+  });
+});

--- a/apps/dashboard/__tests__/githubUrl.test.ts
+++ b/apps/dashboard/__tests__/githubUrl.test.ts
@@ -41,4 +41,10 @@ describe("normalizeGitHubUrl", () => {
   it("prefixes github.com path without scheme", () => {
     expect(normalizeGitHubUrl("github.com/x/y")).toBe("https://github.com/x/y");
   });
+
+  it("strips .git, trailing slash, and www", () => {
+    expect(normalizeGitHubUrl("https://www.github.com/a/b.git/")).toBe(
+      "https://github.com/a/b",
+    );
+  });
 });

--- a/apps/dashboard/__tests__/parseGitHubUrl.test.ts
+++ b/apps/dashboard/__tests__/parseGitHubUrl.test.ts
@@ -44,4 +44,22 @@ describe("normalizeGitHubUrl", () => {
   it("prefixes owner/repo with github.com", () => {
     expect(normalizeGitHubUrl("foo/bar")).toBe("https://github.com/foo/bar");
   });
+
+  it("strips .git suffix", () => {
+    expect(normalizeGitHubUrl("https://github.com/foo/bar.git")).toBe(
+      "https://github.com/foo/bar",
+    );
+  });
+
+  it("strips trailing slash and www", () => {
+    expect(normalizeGitHubUrl("https://www.github.com/foo/bar/")).toBe(
+      "https://github.com/foo/bar",
+    );
+  });
+
+  it("collapses .git and bare URL to the same canonical form", () => {
+    expect(normalizeGitHubUrl("https://github.com/JoshuaC-coder/repometricstest.git")).toBe(
+      normalizeGitHubUrl("https://github.com/JoshuaC-coder/repometricstest"),
+    );
+  });
 });

--- a/apps/dashboard/app/api/analyze/route.ts
+++ b/apps/dashboard/app/api/analyze/route.ts
@@ -12,7 +12,10 @@ import { NextRequest, NextResponse } from "next/server";
 import path from "node:path";
 import os from "node:os";
 import { randomUUID } from "node:crypto";
-import { nextAnalysisVersion } from "@/lib/analysisVersion";
+import {
+  maxAnalysisVersion,
+  nextAnalysisVersion,
+} from "@/lib/analysisVersion";
 import { buildAnalysisResultId } from "@/lib/buildAnalysisResultId";
 import {
   getSupabase,
@@ -280,15 +283,15 @@ export async function POST(request: NextRequest) {
           .select("version")
           .eq("user_id", userId)
           .eq("repo_url", normalizedUrl)
-          .order("version", { ascending: false })
+          .not("version", "is", null)
+          .order("version", { ascending: false, nullsFirst: false })
           .limit(1);
 
         if (maxError) {
           console.error("[analyze] Supabase max version lookup failed:", maxError);
         }
 
-        const maxVersion =
-          maxRows?.[0]?.version != null ? Number(maxRows[0].version) : null;
+        const maxVersion = maxAnalysisVersion(maxRows ?? []);
         const decided = nextAnalysisVersion({
           latestCommit: latestRow?.commit_sha ?? null,
           latestVersion:

--- a/apps/dashboard/app/api/analyze/route.ts
+++ b/apps/dashboard/app/api/analyze/route.ts
@@ -12,6 +12,7 @@ import { NextRequest, NextResponse } from "next/server";
 import path from "node:path";
 import os from "node:os";
 import { randomUUID } from "node:crypto";
+import { nextAnalysisVersion } from "@/lib/analysisVersion";
 import { buildAnalysisResultId } from "@/lib/buildAnalysisResultId";
 import {
   getSupabase,
@@ -54,6 +55,8 @@ function analysesUpsertLooksLikeStaleSchema(error: {
     /\bteam_name\b/i.test(blob) ||
     /\bgithub_login\b/i.test(blob) ||
     /\bdoc_review_json\b/i.test(blob) ||
+    (/\bversion\b/i.test(blob) &&
+      (/\banalyses\b/i.test(blob) || error.code === "PGRST204")) ||
     (/\banalyses\b/.test(lowered) &&
       /\bcolumn\b/.test(lowered) &&
       /\b(find|exist|unknown|undefined)\b/.test(lowered))
@@ -61,7 +64,7 @@ function analysesUpsertLooksLikeStaleSchema(error: {
 }
 
 const ANALYSES_MIGRATION_HINT =
-  "Add columns on public.analyses: run supabase/migrations/20260522000000_analyses_course_metadata.sql in the Supabase SQL Editor (or the full snippet in supabase/run_in_dashboard_sql_editor.sql).";
+  "Add columns on public.analyses: run supabase/migrations/20260522000000_analyses_course_metadata.sql and supabase/migrations/20260709120000_analyses_version.sql in the Supabase SQL Editor (or the full snippet in supabase/run_in_dashboard_sql_editor.sql).";
 
 const ANALYSES_REPO_COMMIT_UNIQUE_HINT =
   "Run supabase/migrations/20260707120000_drop_analyses_repo_commit_unique.sql in the Supabase SQL Editor (or the full snippet in supabase/run_in_dashboard_sql_editor.sql).";
@@ -254,6 +257,65 @@ export async function POST(request: NextRequest) {
     }
 
     if (isSupabaseConfigured()) {
+      let version = 1;
+      let sameCommit = false;
+
+      if (userId) {
+        const sb = getSupabase();
+        const { data: latestRow, error: latestError } = await sb
+          .from("analyses")
+          .select("result_id, commit_sha, version")
+          .eq("user_id", userId)
+          .eq("repo_url", normalizedUrl)
+          .order("analyzed_at", { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        if (latestError) {
+          console.error("[analyze] Supabase latest analysis lookup failed:", latestError);
+        }
+
+        const { data: maxRows, error: maxError } = await sb
+          .from("analyses")
+          .select("version")
+          .eq("user_id", userId)
+          .eq("repo_url", normalizedUrl)
+          .order("version", { ascending: false })
+          .limit(1);
+
+        if (maxError) {
+          console.error("[analyze] Supabase max version lookup failed:", maxError);
+        }
+
+        const maxVersion =
+          maxRows?.[0]?.version != null ? Number(maxRows[0].version) : null;
+        const decided = nextAnalysisVersion({
+          latestCommit: latestRow?.commit_sha ?? null,
+          latestVersion:
+            latestRow?.version != null ? Number(latestRow.version) : null,
+          maxVersion,
+          newCommit: commitSha,
+        });
+        version = decided.version;
+        sameCommit = decided.sameCommit;
+
+        // Replace legacy rows for this user+repo+commit (old result_id format),
+        // but never delete the canonical row we are about to upsert.
+        if (sameCommit && commitSha) {
+          const { error: deleteError } = await sb
+            .from("analyses")
+            .delete()
+            .eq("user_id", userId)
+            .eq("repo_url", normalizedUrl)
+            .eq("commit_sha", commitSha)
+            .neq("result_id", resultId);
+
+          if (deleteError) {
+            console.error("[analyze] Supabase delete legacy row failed:", deleteError);
+          }
+        }
+      }
+
       const row = {
         result_id: resultId,
         repo_url: normalizedUrl,
@@ -263,21 +325,8 @@ export async function POST(request: NextRequest) {
         course_id: courseIdVal,
         team_name: teamNameVal,
         github_login: githubLogin,
+        version,
       };
-
-      // Replace any legacy row for this user+repo+commit (old result_id format).
-      if (userId && commitSha) {
-        const { error: deleteError } = await getSupabase()
-          .from("analyses")
-          .delete()
-          .eq("user_id", userId)
-          .eq("repo_url", normalizedUrl)
-          .eq("commit_sha", commitSha);
-
-        if (deleteError) {
-          console.error("[analyze] Supabase delete legacy row failed:", deleteError);
-        }
-      }
 
       const { error } = await getSupabase()
         .from("analyses")

--- a/apps/dashboard/lib/analysisVersion.ts
+++ b/apps/dashboard/lib/analysisVersion.ts
@@ -16,9 +16,27 @@ export type NextAnalysisVersionResult = {
 };
 
 /**
+ * Read-side: highest numeric version from query rows, ignoring nulls.
+ * Does not decide the next version — pass the result into nextAnalysisVersion.
+ */
+export function maxAnalysisVersion(
+  rows: ReadonlyArray<{ version: number | null | undefined }>,
+): number | null {
+  let max: number | null = null;
+  for (const row of rows) {
+    if (row.version == null) continue;
+    const n = Number(row.version);
+    if (!Number.isFinite(n)) continue;
+    if (max == null || n > max) max = n;
+  }
+  return max;
+}
+
+/**
  * Decide the analyses.version for a new save.
  * Same commit as latest → keep that version; otherwise max+1 (or 1).
  * Null commit on either side is treated as changed (bump).
+ * Does not call maxAnalysisVersion — callers supply maxVersion.
  */
 export function nextAnalysisVersion({
   latestCommit,

--- a/apps/dashboard/lib/analysisVersion.ts
+++ b/apps/dashboard/lib/analysisVersion.ts
@@ -1,0 +1,45 @@
+export type NextAnalysisVersionInput = {
+  /** Latest analysis commit for this user+repo (by analyzed_at), if any. */
+  latestCommit: string | null;
+  /** Version on that latest row, if any. */
+  latestVersion: number | null;
+  /** Max version across all rows for this user+repo. */
+  maxVersion: number | null;
+  /** Commit SHA of the analysis about to be saved. */
+  newCommit: string | null;
+};
+
+export type NextAnalysisVersionResult = {
+  version: number;
+  /** True when commit matches the latest row — overwrite that version. */
+  sameCommit: boolean;
+};
+
+/**
+ * Decide the analyses.version for a new save.
+ * Same commit as latest → keep that version; otherwise max+1 (or 1).
+ * Null commit on either side is treated as changed (bump).
+ */
+export function nextAnalysisVersion({
+  latestCommit,
+  latestVersion,
+  maxVersion,
+  newCommit,
+}: NextAnalysisVersionInput): NextAnalysisVersionResult {
+  const sameCommit =
+    latestCommit != null &&
+    newCommit != null &&
+    latestCommit === newCommit;
+
+  if (sameCommit) {
+    return {
+      version: latestVersion ?? maxVersion ?? 1,
+      sameCommit: true,
+    };
+  }
+
+  return {
+    version: (maxVersion ?? 0) + 1,
+    sameCommit: false,
+  };
+}

--- a/apps/dashboard/lib/github/parseGitHubUrl.ts
+++ b/apps/dashboard/lib/github/parseGitHubUrl.ts
@@ -1,3 +1,15 @@
+function stripTrailingSlashes(value: string): string {
+  let out = value;
+  while (out.endsWith("/")) out = out.slice(0, -1);
+  return out;
+}
+
+function stripGitSuffix(value: string): string {
+  return value.length >= 4 && value.toLowerCase().endsWith(".git")
+    ? value.slice(0, -4)
+    : value;
+}
+
 export function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
   const trimmed = url.trim();
   const full = trimmed.startsWith("http")
@@ -7,7 +19,7 @@ export function parseGitHubUrl(url: string): { owner: string; repo: string } | n
     /(?:https?:\/\/)?(?:www\.)?github\.com\/([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)/,
   );
   if (!m) return null;
-  return { owner: m[1]!, repo: m[2]!.replace(/\.git$/i, "") };
+  return { owner: m[1]!, repo: stripGitSuffix(m[2]!) };
 }
 
 export function isValidGitHubUrl(input: string): boolean {
@@ -27,12 +39,31 @@ export function normalizeGitHubUrl(url: string): string {
   if (parsed) {
     return `https://github.com/${parsed.owner}/${parsed.repo}`;
   }
-  let trimmed = url.trim().replace(/\/+$/, "").replace(/\.git$/i, "");
+
+  // Best-effort fallback without polynomial regexes or host substring checks.
+  let trimmed = stripGitSuffix(stripTrailingSlashes(url.trim()));
   if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
-    return trimmed.replace(/^(https?:\/\/)www\./i, "$1");
+    try {
+      const u = new URL(trimmed);
+      if (u.hostname.toLowerCase() === "www.github.com") {
+        u.hostname = "github.com";
+      }
+      return stripGitSuffix(stripTrailingSlashes(u.toString()));
+    } catch {
+      return trimmed;
+    }
   }
-  if (trimmed.includes("/") && !trimmed.includes("github.com")) {
+
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("github.com/") || lower.startsWith("www.github.com/")) {
+    const withoutWww = lower.startsWith("www.") ? trimmed.slice(4) : trimmed;
+    return `https://${withoutWww}`;
+  }
+
+  // owner/repo shorthand (no scheme/host)
+  if (trimmed.includes("/") && !trimmed.includes("://")) {
     return `https://github.com/${trimmed}`;
   }
-  return `https://${trimmed.replace(/^www\./i, "")}`;
+
+  return `https://${trimmed}`;
 }

--- a/apps/dashboard/lib/github/parseGitHubUrl.ts
+++ b/apps/dashboard/lib/github/parseGitHubUrl.ts
@@ -7,7 +7,7 @@ export function parseGitHubUrl(url: string): { owner: string; repo: string } | n
     /(?:https?:\/\/)?(?:www\.)?github\.com\/([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)/,
   );
   if (!m) return null;
-  return { owner: m[1]!, repo: m[2]!.replace(/\.git$/, "") };
+  return { owner: m[1]!, repo: m[2]!.replace(/\.git$/i, "") };
 }
 
 export function isValidGitHubUrl(input: string): boolean {
@@ -18,11 +18,21 @@ export function isValidGitHubUrl(input: string): boolean {
   );
 }
 
+/**
+ * Canonical repo URL for storage/lookups: https://github.com/{owner}/{repo}
+ * Strips www, .git, and trailing slashes so versioning keys stay stable.
+ */
 export function normalizeGitHubUrl(url: string): string {
-  const trimmed = url.trim();
-  if (trimmed.startsWith("http")) return trimmed;
+  const parsed = parseGitHubUrl(url);
+  if (parsed) {
+    return `https://github.com/${parsed.owner}/${parsed.repo}`;
+  }
+  let trimmed = url.trim().replace(/\/+$/, "").replace(/\.git$/i, "");
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    return trimmed.replace(/^(https?:\/\/)www\./i, "$1");
+  }
   if (trimmed.includes("/") && !trimmed.includes("github.com")) {
     return `https://github.com/${trimmed}`;
   }
-  return `https://${trimmed}`;
+  return `https://${trimmed.replace(/^www\./i, "")}`;
 }

--- a/apps/dashboard/lib/githubUrl.ts
+++ b/apps/dashboard/lib/githubUrl.ts
@@ -15,13 +15,32 @@ export function isValidGitHubUrl(input: string): boolean {
   return GITHUB_URL_RE.test(trimmed);
 }
 
+/**
+ * Canonical repo URL: https://github.com/{owner}/{repo}
+ * Strips www, .git, and trailing slashes.
+ */
 export function normalizeGitHubUrl(input: string): string {
   const trimmed = input.trim();
-  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
-    return trimmed;
+  const ownerRepo =
+    trimmed.match(
+      /^(?:https?:\/\/)?(?:www\.)?github\.com\/([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+?)(?:\.git)?\/?$/i,
+    ) ??
+    (OWNER_REPO_RE.test(trimmed)
+      ? trimmed.match(/^([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+?)(?:\.git)?$/i)
+      : null);
+
+  if (ownerRepo) {
+    const owner = ownerRepo[1]!;
+    const repo = ownerRepo[2]!.replace(/\.git$/i, "");
+    return `https://github.com/${owner}/${repo}`;
   }
-  if (OWNER_REPO_RE.test(trimmed)) {
-    return `https://github.com/${trimmed}`;
+
+  let fallback = trimmed.replace(/\/+$/, "").replace(/\.git$/i, "");
+  if (fallback.startsWith("http://") || fallback.startsWith("https://")) {
+    return fallback.replace(/^(https?:\/\/)www\./i, "$1");
   }
-  return `https://${trimmed}`;
+  if (OWNER_REPO_RE.test(fallback)) {
+    return `https://github.com/${fallback}`;
+  }
+  return `https://${fallback.replace(/^www\./i, "")}`;
 }

--- a/apps/dashboard/lib/githubUrl.ts
+++ b/apps/dashboard/lib/githubUrl.ts
@@ -7,6 +7,18 @@ const GITHUB_URL_RE =
   /^(?:https?:\/\/)?(?:www\.)?github\.com\/([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)(?:\/)?(?:\.[a-zA-Z]+)?$/;
 const OWNER_REPO_RE = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 
+function stripTrailingSlashes(value: string): string {
+  let out = value;
+  while (out.endsWith("/")) out = out.slice(0, -1);
+  return out;
+}
+
+function stripGitSuffix(value: string): string {
+  return value.length >= 4 && value.toLowerCase().endsWith(".git")
+    ? value.slice(0, -4)
+    : value;
+}
+
 export function isValidGitHubUrl(input: string): boolean {
   if (!input || typeof input !== "string") return false;
   const trimmed = input.trim();
@@ -21,26 +33,45 @@ export function isValidGitHubUrl(input: string): boolean {
  */
 export function normalizeGitHubUrl(input: string): string {
   const trimmed = input.trim();
-  const ownerRepo =
-    trimmed.match(
-      /^(?:https?:\/\/)?(?:www\.)?github\.com\/([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+?)(?:\.git)?\/?$/i,
-    ) ??
-    (OWNER_REPO_RE.test(trimmed)
-      ? trimmed.match(/^([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+?)(?:\.git)?$/i)
-      : null);
 
-  if (ownerRepo) {
-    const owner = ownerRepo[1]!;
-    const repo = ownerRepo[2]!.replace(/\.git$/i, "");
+  // Prefer URL parsing for absolute URLs so host checks are exact.
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    try {
+      const u = new URL(trimmed);
+      const host = u.hostname.toLowerCase();
+      if (host === "github.com" || host === "www.github.com") {
+        const parts = u.pathname.split("/").filter(Boolean);
+        if (parts.length >= 2) {
+          const owner = parts[0]!;
+          const repo = stripGitSuffix(parts[1]!);
+          if (
+            /^[a-zA-Z0-9_.-]+$/.test(owner) &&
+            /^[a-zA-Z0-9_.-]+$/.test(repo)
+          ) {
+            return `https://github.com/${owner}/${repo}`;
+          }
+        }
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  const ownerRepoMatch = trimmed.match(
+    /^(?:(?:https?:\/\/)?(?:www\.)?github\.com\/)?([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)$/i,
+  );
+  if (ownerRepoMatch) {
+    const owner = ownerRepoMatch[1]!;
+    const repo = stripGitSuffix(ownerRepoMatch[2]!);
     return `https://github.com/${owner}/${repo}`;
   }
 
-  let fallback = trimmed.replace(/\/+$/, "").replace(/\.git$/i, "");
-  if (fallback.startsWith("http://") || fallback.startsWith("https://")) {
-    return fallback.replace(/^(https?:\/\/)www\./i, "$1");
-  }
+  const fallback = stripGitSuffix(stripTrailingSlashes(trimmed));
   if (OWNER_REPO_RE.test(fallback)) {
     return `https://github.com/${fallback}`;
   }
-  return `https://${fallback.replace(/^www\./i, "")}`;
+  if (fallback.startsWith("http://") || fallback.startsWith("https://")) {
+    return fallback;
+  }
+  return `https://${fallback}`;
 }

--- a/packages/engine/src/pipeline/analyzeFromGitHubUrl.ts
+++ b/packages/engine/src/pipeline/analyzeFromGitHubUrl.ts
@@ -24,25 +24,54 @@ export interface AnalyzeFromGitHubUrlOptions {
   githubToken?: string;
 }
 
+function stripTrailingSlashes(value: string): string {
+  let out = value;
+  while (out.endsWith("/")) out = out.slice(0, -1);
+  return out;
+}
+
+function stripGitSuffix(value: string): string {
+  return value.length >= 4 && value.toLowerCase().endsWith(".git")
+    ? value.slice(0, -4)
+    : value;
+}
+
+/**
+ * Canonical https://github.com/{owner}/{repo} for clone/API paths.
+ * Avoids substring host checks and polynomial trailing-slash regexes (CodeQL).
+ */
 function normalizeGitHubUrl(input: string): string {
   const trimmed = input.trim();
-  // Prefer engine parse so .git / trailing slash collapse to canonical URL.
-  const early = parseGitHubUrl(
-    trimmed.startsWith("http://") || trimmed.startsWith("https://")
-      ? trimmed.replace(/^http:\/\//i, "https://").replace(/^(https:\/\/)www\./i, "$1")
-      : trimmed.includes("/") && !trimmed.includes("github.com")
-        ? `https://github.com/${trimmed}`
-        : `https://${trimmed.replace(/^www\./i, "")}`,
-  );
-  if (early) return early.url;
+  let candidate = trimmed;
 
-  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
-    return trimmed.replace(/\/+$/, "").replace(/\.git$/i, "");
+  if (trimmed.startsWith("http://")) {
+    candidate = `https://${trimmed.slice("http://".length)}`;
+  } else if (!trimmed.startsWith("https://")) {
+    const lower = trimmed.toLowerCase();
+    if (lower.startsWith("github.com/") || lower.startsWith("www.github.com/")) {
+      candidate = `https://${lower.startsWith("www.") ? trimmed.slice(4) : trimmed}`;
+    } else if (!trimmed.includes("://") && trimmed.includes("/")) {
+      // owner/repo shorthand (no scheme)
+      candidate = `https://github.com/${trimmed}`;
+    } else {
+      candidate = `https://${trimmed}`;
+    }
   }
-  if (trimmed.includes("/") && !trimmed.includes("github.com")) {
-    return `https://github.com/${trimmed.replace(/\.git$/i, "")}`;
+
+  try {
+    const u = new URL(candidate);
+    if (u.hostname.toLowerCase() === "www.github.com") {
+      u.hostname = "github.com";
+      candidate = u.toString();
+    }
+  } catch {
+    // keep candidate
   }
-  return `https://${trimmed}`;
+
+  const parsed = parseGitHubUrl(candidate);
+  if (parsed) return parsed.url;
+
+  return stripGitSuffix(stripTrailingSlashes(candidate));
 }
 
 function isGitUnavailable(err: unknown): boolean {

--- a/packages/engine/src/pipeline/analyzeFromGitHubUrl.ts
+++ b/packages/engine/src/pipeline/analyzeFromGitHubUrl.ts
@@ -26,11 +26,21 @@ export interface AnalyzeFromGitHubUrlOptions {
 
 function normalizeGitHubUrl(input: string): string {
   const trimmed = input.trim();
+  // Prefer engine parse so .git / trailing slash collapse to canonical URL.
+  const early = parseGitHubUrl(
+    trimmed.startsWith("http://") || trimmed.startsWith("https://")
+      ? trimmed.replace(/^http:\/\//i, "https://").replace(/^(https:\/\/)www\./i, "$1")
+      : trimmed.includes("/") && !trimmed.includes("github.com")
+        ? `https://github.com/${trimmed}`
+        : `https://${trimmed.replace(/^www\./i, "")}`,
+  );
+  if (early) return early.url;
+
   if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
-    return trimmed;
+    return trimmed.replace(/\/+$/, "").replace(/\.git$/i, "");
   }
   if (trimmed.includes("/") && !trimmed.includes("github.com")) {
-    return `https://github.com/${trimmed}`;
+    return `https://github.com/${trimmed.replace(/\.git$/i, "")}`;
   }
   return `https://${trimmed}`;
 }

--- a/packages/engine/src/utils/githubUrl.ts
+++ b/packages/engine/src/utils/githubUrl.ts
@@ -21,7 +21,8 @@ export interface ParsedGitHubUrl {
  * @returns Parsed URL with owner and repo, or null if invalid.
  */
 export function parseGitHubUrl(input: string): ParsedGitHubUrl | null {
-  const normalized = input.trim().replace(/\/+$/, "");
+  let normalized = input.trim();
+  while (normalized.endsWith("/")) normalized = normalized.slice(0, -1);
   const match = normalized.match(GITHUB_URL_RE);
   if (!match) return null;
   let [, owner, repo] = match;

--- a/supabase/migrations/20260709120000_analyses_version.sql
+++ b/supabase/migrations/20260709120000_analyses_version.sql
@@ -1,0 +1,28 @@
+-- Per-user+repo analysis version (append on commit change).
+-- Existing rows are numbered chronologically within (user_id, repo_url).
+
+alter table public.analyses
+  add column if not exists version integer;
+
+comment on column public.analyses.version is
+  'Monotonic version for this user_id + repo_url; bumps when commit_sha changes.';
+
+-- Backfill: oldest analysis for each user+repo is version 1.
+with ranked as (
+  select
+    result_id,
+    row_number() over (
+      partition by user_id, repo_url
+      order by analyzed_at asc nulls last, result_id asc
+    ) as rn
+  from public.analyses
+  where version is null
+)
+update public.analyses a
+set version = ranked.rn
+from ranked
+where a.result_id = ranked.result_id
+  and a.version is null;
+
+create index if not exists analyses_user_repo_version_idx
+  on public.analyses (user_id, repo_url, version desc);

--- a/supabase/migrations/20260710140000_analyses_version_renumber.sql
+++ b/supabase/migrations/20260710140000_analyses_version_renumber.sql
@@ -1,0 +1,27 @@
+-- Repair analyses.version after NULL-poisoned max lookups left duplicate 1s.
+-- Reassigns version chronologically within (user_id, repo_url) for ALL rows.
+--
+-- Preflight (run in SQL Editor before applying on hosted DB):
+--   select count(*) from public.analyses where analyzed_at is null;  -- expect 0
+--   select result_id, commit_sha, version as version_before, analyzed_at,
+--     row_number() over (
+--       partition by user_id, repo_url
+--       order by analyzed_at asc nulls last, result_id asc
+--     ) as version_after
+--   from public.analyses
+--   where repo_url ilike '%repometricstest%'
+--   order by user_id, analyzed_at;
+
+with ranked as (
+  select
+    result_id,
+    row_number() over (
+      partition by user_id, repo_url
+      order by analyzed_at asc nulls last, result_id asc
+    ) as rn
+  from public.analyses
+)
+update public.analyses a
+set version = ranked.rn
+from ranked
+where a.result_id = ranked.result_id;

--- a/supabase/migrations/20260710150000_analyses_canonicalize_repo_url.sql
+++ b/supabase/migrations/20260710150000_analyses_canonicalize_repo_url.sql
@@ -1,0 +1,33 @@
+-- Canonicalize analyses.repo_url so .git / bare URLs share one version sequence.
+-- Then renumber version chronologically within (user_id, repo_url).
+
+-- Strip trailing slashes, then trailing .git; drop www. on github.com host.
+update public.analyses
+set repo_url = regexp_replace(
+  regexp_replace(
+    regexp_replace(repo_url, '/+$', ''),
+    '\.git$',
+    '',
+    'i'
+  ),
+  '^(https?://)www\.(github\.com)',
+  '\1\2',
+  'i'
+)
+where repo_url ~* '\.git/?$'
+   or repo_url ~ '/$'
+   or repo_url ~* '://www\.github\.com';
+
+with ranked as (
+  select
+    result_id,
+    row_number() over (
+      partition by user_id, repo_url
+      order by analyzed_at asc nulls last, result_id asc
+    ) as rn
+  from public.analyses
+)
+update public.analyses a
+set version = ranked.rn
+from ranked
+where a.result_id = ranked.result_id;

--- a/supabase/run_in_dashboard_sql_editor.sql
+++ b/supabase/run_in_dashboard_sql_editor.sql
@@ -83,3 +83,50 @@ where a.result_id = ranked.result_id
 
 create index if not exists analyses_user_repo_version_idx
   on public.analyses (user_id, repo_url, version desc);
+
+-- Repair: renumber all versions chronologically (fixes NULL / duplicate-1 rows).
+-- Preflight: select count(*) from public.analyses where analyzed_at is null;
+with ranked_all as (
+  select
+    result_id,
+    row_number() over (
+      partition by user_id, repo_url
+      order by analyzed_at asc nulls last, result_id asc
+    ) as rn
+  from public.analyses
+)
+update public.analyses a
+set version = ranked_all.rn
+from ranked_all
+where a.result_id = ranked_all.result_id;
+
+-- Canonicalize repo_url (.git vs bare) then renumber versions again.
+update public.analyses
+set repo_url = regexp_replace(
+  regexp_replace(
+    regexp_replace(repo_url, '/+$', ''),
+    '\.git$',
+    '',
+    'i'
+  ),
+  '^(https?://)www\.(github\.com)',
+  '\1\2',
+  'i'
+)
+where repo_url ~* '\.git/?$'
+   or repo_url ~ '/$'
+   or repo_url ~* '://www\.github\.com';
+
+with ranked_canonical as (
+  select
+    result_id,
+    row_number() over (
+      partition by user_id, repo_url
+      order by analyzed_at asc nulls last, result_id asc
+    ) as rn
+  from public.analyses
+)
+update public.analyses a
+set version = ranked_canonical.rn
+from ranked_canonical
+where a.result_id = ranked_canonical.result_id;

--- a/supabase/run_in_dashboard_sql_editor.sql
+++ b/supabase/run_in_dashboard_sql_editor.sql
@@ -57,3 +57,29 @@ comment on column public.analyses.doc_review_json is
 -- Per-user analyses (SIP 2.3.4): allow multiple users on same repo+commit.
 alter table public.analyses
   drop constraint if exists analyses_repo_commit_unique;
+
+-- Per-user+repo analysis version (append on commit change).
+alter table public.analyses
+  add column if not exists version integer;
+
+comment on column public.analyses.version is
+  'Monotonic version for this user_id + repo_url; bumps when commit_sha changes.';
+
+with ranked as (
+  select
+    result_id,
+    row_number() over (
+      partition by user_id, repo_url
+      order by analyzed_at asc nulls last, result_id asc
+    ) as rn
+  from public.analyses
+  where version is null
+)
+update public.analyses a
+set version = ranked.rn
+from ranked
+where a.result_id = ranked.result_id
+  and a.version is null;
+
+create index if not exists analyses_user_repo_version_idx
+  on public.analyses (user_id, repo_url, version desc);


### PR DESCRIPTION
## Summary
- Add `analyses.version` so the same user keeps a new row when the default-branch tip commit changes; same commit overwrites.
- Fix null-poisoned max-version lookup and canonicalize `repo_url` (strip `.git` / trailing `/` / `www.`) so URL variants share one version sequence.
- Include SQL migrations to add/renumber versions and repair existing rows.

Closes #214

## Test plan
- [x] Run version + canonicalize SQL on Supabase (or confirm already applied)
- [x] Analyze a repo, then re-analyze same tip → no new row, same version
- [x] Push to default branch and analyze again → new row, version = max+1
- [x] Analyze with `.git` vs bare URL → same version sequence
- [x] Unit tests: `analysisVersion`, `parseGitHubUrl` / `githubUrl` normalize cases